### PR TITLE
Add datagram tag bits to RX packet message

### DIFF
--- a/src/hotspot_protocol/longfi.proto
+++ b/src/hotspot_protocol/longfi.proto
@@ -44,14 +44,17 @@ message LongFiRxPacket {
     uint32 oui = 5;
     // Device ID
     uint32 device_id = 6;
-    // Fingerprint 
+    // Fingerprint
     uint32 fingerprint = 7;
-    // Sequence 
+    // Sequence
     uint32 sequence = 9;
     // Spreading to be used
     LongFiSpreading spreading = 10;
     // the fully reassembled payload
     bytes payload = 11;
+    // De-golayed datagram id and flag bits.
+    // NOTE: only the lowest 12 bits are valid.
+    uint32 tag_bits = 12;
 }
 
 message LongFiTxPacket {
@@ -71,9 +74,9 @@ message LongFiTxPacket {
     uint32 oui = 6;
     // Device ID
     uint32 device_id = 7;
-    // Fingerprint 
+    // Fingerprint
     uint32 fingerpint = 8;
-    // Sequence 
+    // Sequence
     uint32 sequence = 9;
     // Spreading to be used
     LongFiSpreading spreading = 10;


### PR DESCRIPTION
Routers need the original golay-decoded tag bits to verify datagram fingerprints. This PR adds them in the most unobtrusive, if not pretty, way. 

Ideally, in a future PR, we'll make `LongFiRxPacket` contain a `one_of datagram`. It's not needed now though since we're only using `monolithic` datagrams.