### PR TITLE
Flatten to helium namespace to avoid tool interactions

### DIFF
--- a/src/blockchain_state_channel_v1.proto
+++ b/src/blockchain_state_channel_v1.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package helium.txns;
+package helium;
 
-import "helium_packet.proto";
+import "packet.proto";
 
 enum blockchain_state_channel_state_v1 {
     open = 0;
@@ -37,11 +37,11 @@ message blockchain_state_channel_response_v1 {
     bool accepted = 1;
     bytes req_hash = 2;
     blockchain_state_channel_update_v1 state_channel_update = 3;
-    helium.packet.helium_packet downlink = 4;
+    packet downlink = 4;
 }
 
 message blockchain_state_channel_packet_v1 {
-    helium.packet.helium_packet packet = 1;
+    packet packet = 1;
     bytes hotspot = 2;
     bytes signature = 3;
 }

--- a/src/blockchain_txn.proto
+++ b/src/blockchain_txn.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package helium.txns;
+package helium;
 
 import "blockchain_txn_coinbase_v1.proto";
 import "blockchain_txn_security_coinbase_v1.proto";

--- a/src/blockchain_txn_add_gateway_v1.proto
+++ b/src/blockchain_txn_add_gateway_v1.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package helium.txns;
+package helium;
 
 message blockchain_txn_add_gateway_v1 {
     bytes owner = 1;

--- a/src/blockchain_txn_assert_location_v1.proto
+++ b/src/blockchain_txn_assert_location_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_assert_location_v1 {
     bytes gateway = 1;

--- a/src/blockchain_txn_coinbase_v1.proto
+++ b/src/blockchain_txn_coinbase_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_coinbase_v1 {
     bytes payee = 1;

--- a/src/blockchain_txn_consensus_group_v1.proto
+++ b/src/blockchain_txn_consensus_group_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_consensus_group_v1 {
     repeated bytes members = 1;

--- a/src/blockchain_txn_create_htlc_v1.proto
+++ b/src/blockchain_txn_create_htlc_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_create_htlc_v1 {
     bytes payer = 1;

--- a/src/blockchain_txn_dc_coinbase_v1.proto
+++ b/src/blockchain_txn_dc_coinbase_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_dc_coinbase_v1 {
     bytes payee = 1;

--- a/src/blockchain_txn_gen_gateway_v1.proto
+++ b/src/blockchain_txn_gen_gateway_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_gen_gateway_v1 {
     bytes gateway = 1;

--- a/src/blockchain_txn_oui_v1.proto
+++ b/src/blockchain_txn_oui_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_oui_v1 {
     bytes owner = 1;

--- a/src/blockchain_txn_payment_v1.proto
+++ b/src/blockchain_txn_payment_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_payment_v1 {
     bytes payer = 1;

--- a/src/blockchain_txn_poc_receipts_v1.proto
+++ b/src/blockchain_txn_poc_receipts_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 enum origin {
     p2p = 0;

--- a/src/blockchain_txn_poc_request_v1.proto
+++ b/src/blockchain_txn_poc_request_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_poc_request_v1 {
     bytes challenger = 1;

--- a/src/blockchain_txn_redeem_htlc_v1.proto
+++ b/src/blockchain_txn_redeem_htlc_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_redeem_htlc_v1 {
     bytes payee = 1;

--- a/src/blockchain_txn_rewards_v1.proto
+++ b/src/blockchain_txn_rewards_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_reward_v1 {
     enum Type {

--- a/src/blockchain_txn_routing_v1.proto
+++ b/src/blockchain_txn_routing_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_routing_v1 {
     uint32 oui = 1;

--- a/src/blockchain_txn_security_coinbase_v1.proto
+++ b/src/blockchain_txn_security_coinbase_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_security_coinbase_v1 {
     bytes payee = 1;

--- a/src/blockchain_txn_security_exchange_v1.proto
+++ b/src/blockchain_txn_security_exchange_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_security_exchange_v1 {
     bytes payer = 1;

--- a/src/blockchain_txn_state_channel_close_v1.proto
+++ b/src/blockchain_txn_state_channel_close_v1.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package helium.txns;
+package helium;
 
 import "blockchain_state_channel_v1.proto";
 

--- a/src/blockchain_txn_state_channel_open_v1.proto
+++ b/src/blockchain_txn_state_channel_open_v1.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package helium.txns;
+package helium;
 
 message blockchain_txn_state_channel_open_v1 {
     bytes id = 1;

--- a/src/blockchain_txn_token_burn_exchange_rate_v1.proto
+++ b/src/blockchain_txn_token_burn_exchange_rate_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_token_burn_exchange_rate_v1 {
     uint64 rate = 1;

--- a/src/blockchain_txn_token_burn_v1.proto
+++ b/src/blockchain_txn_token_burn_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_token_burn_v1 {
     enum Type {

--- a/src/blockchain_txn_update_gateway_oui_v1.proto
+++ b/src/blockchain_txn_update_gateway_oui_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_txn_update_gateway_oui_v1 {
     bytes gateway = 1;

--- a/src/blockchain_txn_vars_v1.proto
+++ b/src/blockchain_txn_vars_v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package helium.txns;
+package helium;
 
 message blockchain_var_v1 {
     string name = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,3 @@
-pub mod blockchain {
-    include!(concat!(env!("OUT_DIR"), "/helium.txns.rs"));
-    pub use blockchain_txn::Txn;
-}
-
-pub mod packet {
-    include!(concat!(env!("OUT_DIR"), "/helium.packet.rs"));
-}
-
+include!(concat!(env!("OUT_DIR"), "/helium.rs"));
+pub use blockchain_txn::Txn;
 pub use prost::Message;

--- a/src/packet.proto
+++ b/src/packet.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package helium.packet;
+package helium;
 
-message helium_packet {
+message packet {
     uint32 oui = 1;
     enum packet_type {
         longfi = 0;


### PR DESCRIPTION
This flattens the namespace to just `helium` to avoid cross language issues with tools that don't support protobuf packages well