### PR TITLE
add nonce to create_htlc txns

### DIFF
--- a/src/blockchain_txn_create_htlc_v1.proto
+++ b/src/blockchain_txn_create_htlc_v1.proto
@@ -10,4 +10,5 @@ message blockchain_txn_create_htlc_v1 {
     uint64 amount = 6;
     uint64 fee = 7;
     bytes signature = 8;
+    uint64 nonce = 9;
 }


### PR DESCRIPTION
This adds a nonce to the `blockchain_txn_create_htlc_v1` txn type and is to enable absorbed/2 checks in blockchain core.  The related blockchain core PR is:

https://github.com/helium/blockchain-core/pull/305