### PR TITLE
More state channel related fixes

### DIFF
--- a/src/blockchain_txn_oui_v1.proto
+++ b/src/blockchain_txn_oui_v1.proto
@@ -6,10 +6,9 @@ message blockchain_txn_oui_v1 {
     repeated bytes addresses = 2;
     bytes filter = 3;
     uint32 requested_subnet_size = 4;
-    uint64 oui = 5;
-    bytes payer = 6;
-    uint64 staking_fee = 7;
-    uint64 fee = 8;
-    bytes owner_signature = 9;
-    bytes payer_signature = 10;
+    bytes payer = 5;
+    uint64 staking_fee = 6;
+    uint64 fee = 7;
+    bytes owner_signature = 8;
+    bytes payer_signature = 9;
 }

--- a/src/blockchain_txn_state_channel_open_v1.proto
+++ b/src/blockchain_txn_state_channel_open_v1.proto
@@ -7,6 +7,7 @@ message blockchain_txn_state_channel_open_v1 {
     bytes owner = 2;
     int64 amount = 3;
     int64 expire_within = 4;
-    uint64 nonce = 5;
-    bytes signature = 6;
+    uint64 oui = 5;
+    uint64 nonce = 6;
+    bytes signature = 7;
 }

--- a/src/packet.proto
+++ b/src/packet.proto
@@ -2,8 +2,20 @@ syntax = "proto3";
 
 package helium;
 
+message eui {
+    uint64 deveui = 1;
+    uint64 appeui = 2;
+}
+
+message routing_information {
+    oneof data {
+        uint32 devaddr = 1;
+        eui eui = 2;
+    }
+}
+
 message packet {
-    uint32 oui = 1;
+    routing_information routing = 1;
     enum packet_type {
         longfi = 0;
         lorawan = 1;


### PR DESCRIPTION
- `blockchain_txn_oui_v1` does not have an OUI field anymore
- `blockchain_txn_state_channel_open_v1` now has an OUI field
- `packet.proto` updated with routing information