### PR TITLE
Be more compatible with older message definitions

### DIFF
--- a/src/blockchain_state_channel_v1.proto
+++ b/src/blockchain_state_channel_v1.proto
@@ -31,7 +31,7 @@ message blockchain_state_channel_v1 {
 
 message blockchain_state_channel_response_v1 {
     bool accepted = 1;
-    packet downlink = 2;
+    packet downlink = 4;
 }
 
 message blockchain_state_channel_packet_v1 {
@@ -42,7 +42,7 @@ message blockchain_state_channel_packet_v1 {
 
 message blockchain_state_channel_message_v1 {
     oneof msg {
-        blockchain_state_channel_packet_v1 packet = 1;
         blockchain_state_channel_response_v1 response = 2;
+        blockchain_state_channel_packet_v1 packet = 4;
     }
 }

--- a/src/packet.proto
+++ b/src/packet.proto
@@ -15,7 +15,7 @@ message routing_information {
 }
 
 message packet {
-    routing_information routing = 1;
+    uint32 oui = 1;
     enum packet_type {
         longfi = 0;
         lorawan = 1;
@@ -27,4 +27,5 @@ message packet {
     float frequency = 6;
     string datarate = 7;
     float snr = 8;
+    routing_information routing = 9;
     }


### PR DESCRIPTION
For some reason we lost the compatibility conversions in the proto merge, this should restore them.