### PR TITLE
Reinstate field 7 for snapshot compatability

### DIFF
--- a/src/blockchain_state_channel_v1.proto
+++ b/src/blockchain_state_channel_v1.proto
@@ -22,8 +22,8 @@ message blockchain_state_channel_v1 {
     uint64 nonce = 4;
     repeated blockchain_state_channel_summary_v1 summaries = 5;
     bytes root_hash = 6;
-    // This is unused
-    // skewed skewed = 7
+    // This is unused but we can't remove it yet
+    bytes skewed = 7;
     blockchain_state_channel_state_v1 state = 8;
     uint64 expire_at_block = 9;
     bytes signature = 10;


### PR DESCRIPTION
We can remove it once we fix snapshots to contain encoded blocks rather than decoded records.