### PR TITLE
rename validator service to gateway

### DIFF
--- a/src/service/gateway.proto
+++ b/src/service/gateway.proto
@@ -23,6 +23,6 @@ message routing_response {
 
 message routing_request { uint64 height = 1; }
 
-service validator {
+service gateway {
   rpc routing(routing_request) returns (stream routing_response);
 }


### PR DESCRIPTION
rename to avoid confusion with the wider validator project