### PR TITLE
Fixups for validator transactions

### DIFF
--- a/src/blockchain_txn_gen_validator_v1.proto
+++ b/src/blockchain_txn_gen_validator_v1.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package helium;
 
 message blockchain_txn_gen_validator_v1 {
-    bytes addr = 1;
-    bytes owner = 2;
-    uint64 stake = 3;
+  bytes address = 1;
+  bytes owner = 2;
+  uint64 stake = 3;
 }

--- a/src/blockchain_txn_stake_validator_v1.proto
+++ b/src/blockchain_txn_stake_validator_v1.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 package helium;
 
 message blockchain_txn_stake_validator_v1 {
-    bytes validator = 1;
-    bytes owner = 2;
-    uint64 stake = 3;
-    bytes validator_signature = 4;
-    bytes owner_signature = 5;
-    uint64 nonce = 6;
-    uint64 fee = 7;
+  bytes address = 1;
+  bytes owner = 2;
+  uint64 stake = 3;
+  bytes validator_signature = 4;
+  bytes owner_signature = 5;
+  uint64 nonce = 6;
+  uint64 fee = 7;
 }

--- a/src/blockchain_txn_transfer_validator_stake_v1.proto
+++ b/src/blockchain_txn_transfer_validator_stake_v1.proto
@@ -2,13 +2,15 @@ syntax = "proto3";
 package helium;
 
 message blockchain_txn_transfer_validator_stake_v1 {
-    bytes old_addr = 1;
-    bytes new_addr = 2;
-    bytes old_owner = 3;
-    bytes new_owner = 4;
-    bytes new_validator_signature = 5;
-    bytes old_owner_signature = 6;
-    bytes new_owner_signature = 7;
-    uint64 fee = 8;
-    uint64 nonce = 9;
+  bytes old_address = 1;
+  bytes new_address = 2;
+  bytes old_owner = 3;
+  bytes new_owner = 4;
+  bytes new_validator_signature = 5;
+  bytes old_owner_signature = 6;
+  bytes new_owner_signature = 7;
+  uint64 fee = 8;
+  // optional amount (in bones) the new owner is transferring to the old owner
+  uint64 amount = 9;
+  uint64 nonce = 19;
 }

--- a/src/blockchain_txn_unstake_validator_v1.proto
+++ b/src/blockchain_txn_unstake_validator_v1.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 package helium;
 
 message blockchain_txn_unstake_validator_v1 {
-    bytes addr = 1;
-    bytes owner = 2;
-    bytes owner_signature = 3;
-    uint64 fee = 4;
-    uint64 nonce = 5;
+  bytes address = 1;
+  bytes owner = 2;
+  bytes owner_signature = 3;
+  uint64 fee = 4;
+  uint64 nonce = 5;
 }

--- a/src/blockchain_txn_validator_heartbeat_v1.proto
+++ b/src/blockchain_txn_validator_heartbeat_v1.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package helium;
 
 message blockchain_txn_validator_heartbeat_v1 {
-    bytes addr = 1;
-    uint32 height = 2;
-    uint32 version = 3;
-    bytes signature = 4;
+  bytes address = 1;
+  uint32 height = 2;
+  uint32 version = 3;
+  bytes signature = 4;
 }


### PR DESCRIPTION
Consistently name validator address `address`. Add an `amount` to stake_transfer which defines the number of bones the new owner will pay the old owner as part of absorbing this transaction