### PR TITLE
No validator signatures

### DIFF
--- a/src/blockchain_txn_stake_validator_v1.proto
+++ b/src/blockchain_txn_stake_validator_v1.proto
@@ -5,8 +5,7 @@ message blockchain_txn_stake_validator_v1 {
   bytes address = 1;
   bytes owner = 2;
   uint64 stake = 3;
-  bytes validator_signature = 4;
-  bytes owner_signature = 5;
-  uint64 nonce = 6;
-  uint64 fee = 7;
+  bytes owner_signature = 4;
+  uint64 nonce = 5;
+  uint64 fee = 6;
 }

--- a/src/blockchain_txn_transfer_validator_stake_v1.proto
+++ b/src/blockchain_txn_transfer_validator_stake_v1.proto
@@ -6,11 +6,10 @@ message blockchain_txn_transfer_validator_stake_v1 {
   bytes new_address = 2;
   bytes old_owner = 3;
   bytes new_owner = 4;
-  bytes new_validator_signature = 5;
-  bytes old_owner_signature = 6;
-  bytes new_owner_signature = 7;
-  uint64 fee = 8;
+  bytes old_owner_signature = 5;
+  bytes new_owner_signature = 6;
+  uint64 fee = 7;
   // optional amount (in bones) the new owner is transferring to the old owner
-  uint64 amount = 9;
-  uint64 nonce = 19;
+  uint64 amount = 8;
+  uint64 nonce = 9;
 }

--- a/src/blockchain_txn_validator_heartbeat_v1.proto
+++ b/src/blockchain_txn_validator_heartbeat_v1.proto
@@ -3,7 +3,7 @@ package helium;
 
 message blockchain_txn_validator_heartbeat_v1 {
   bytes address = 1;
-  uint32 height = 2;
+  uint64 height = 2;
   uint32 version = 3;
   bytes signature = 4;
 }


### PR DESCRIPTION
Validator signatures are present to indicate key ownership, and as such only safety feature.

For simplicity of stake/unstake/transfer flows, remove these validator signature fields.

Also fixes up heartbeat block height to have a uint64 type