### PR TITLE
Spreading with packet size

### DIFF
--- a/src/blockchain_region_param_v1.proto
+++ b/src/blockchain_region_param_v1.proto
@@ -16,8 +16,14 @@ enum RegionSpreading {
     SF12 = 6;
 }
 
+message packet_size_region_spreading {
+    RegionSpreading region_spreading = 1;
+    uint32 packet_size = 2;
+}
+
 message blockchain_region_spreading_v1 {
     repeated RegionSpreading region_spreading = 1;
+    repeated packet_size_region_spreading packet_size_region_spreading = 2;
 }
 
 message blockchain_region_param_v1 {

--- a/src/blockchain_region_param_v1.proto
+++ b/src/blockchain_region_param_v1.proto
@@ -16,14 +16,13 @@ enum RegionSpreading {
     SF12 = 6;
 }
 
-message packet_size_region_spreading {
+message tagged_spreading {
     RegionSpreading region_spreading = 1;
     uint32 max_packet_size = 2;
 }
 
 message blockchain_region_spreading_v1 {
-    repeated RegionSpreading region_spreading = 1;
-    repeated packet_size_region_spreading packet_size_region_spreading = 2;
+    repeated tagged_spreading tagged_spreading = 1;
 }
 
 message blockchain_region_param_v1 {

--- a/src/blockchain_region_param_v1.proto
+++ b/src/blockchain_region_param_v1.proto
@@ -18,7 +18,7 @@ enum RegionSpreading {
 
 message packet_size_region_spreading {
     RegionSpreading region_spreading = 1;
-    uint32 packet_size = 2;
+    uint32 max_packet_size = 2;
 }
 
 message blockchain_region_spreading_v1 {


### PR DESCRIPTION
We have never used the region proto on chain thus it's okay to modify the spreading proto here. We will use this version which has a `max_packet_size` tagged_spreading making it easier to lookup which spreading factor to use on the miner side.