### PR TITLE
Add transfer_hotspot_v2 proto

### DIFF
--- a/src/blockchain_txn.proto
+++ b/src/blockchain_txn.proto
@@ -38,6 +38,7 @@ import "blockchain_txn_unstake_validator_v1.proto";
 import "blockchain_txn_validator_heartbeat_v1.proto";
 
 import "blockchain_txn_assert_location_v2.proto";
+import "blockchain_txn_transfer_hotspot_v2.proto";
 
 message blockchain_txn {
     oneof txn {
@@ -76,6 +77,7 @@ message blockchain_txn {
         blockchain_txn_consensus_group_failure_v1 consensus_group_failure = 33;
         blockchain_txn_rewards_v2 rewards_v2 = 34;
         blockchain_txn_assert_location_v2 assert_location_v2 = 35;
+        blockchain_txn_transfer_hotspot_v2 transfer_hotspot_v2 = 36;
     }
 }
 

--- a/src/blockchain_txn_transfer_hotspot_v2.proto
+++ b/src/blockchain_txn_transfer_hotspot_v2.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package helium;
+
+message blockchain_txn_transfer_hotspot_v2 {
+    bytes gateway = 1;
+    bytes owner = 2;
+    bytes owner_signature = 3;
+    bytes new_owner = 4;
+    uint64 fee = 5;
+}


### PR DESCRIPTION
proto for https://github.com/helium/blockchain-core/issues/978

Preparation for a much simpler version of hotspot transfer transaction containing only:

```
-  owner_signature
-  owner_address
-  gateway_address
-  new_owner_address
```