### PR TITLE
Remove rustfmt in tonic-build dependency by default to allow production builds without rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_derive = "1"
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = {version = "0", optional = true, default-features = false, features = ["transport"] }
+tonic-build = {version = "0", optional = true, default-features = false, features = ["transport", "prost"] }
 prost-build = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_derive = "1"
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = {version = "0", optional = true, default-features = false, features = ["transport", "prost"] }
+tonic-build = {version = "0", optional = true }
 prost-build = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_derive = "1"
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = {version = "0", optional = true}
+tonic-build = {version = "0", optional = true, default-features = false, features = ["transport"] }
 prost-build = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_derive = "1"
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = {version = "0", optional = true }
+tonic-build = {version = "0", optional = true}
 prost-build = "0"

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,13 @@ fn main() -> Result<()> {
     tonic_build::configure()
         .build_server(false)
         .type_attribute(".", "#[derive(serde_derive::Serialize)]")
+        .format(match std::env::var("PROFILE") {
+            Ok(profile) => match profile.as_str() {
+                "release" => (false),
+                _ => (true),
+            },
+            Err(_) => true,
+        })
         .compile(
             &[
                 "src/blockchain_txn.proto",


### PR DESCRIPTION
Actually, by default, rustfmt is needed for all builds. As rustfmt is here only to prettify the generated proto files (very useful for debug), it can be removed for production builds.

I could not find a way to differentiate the build-dependency depending on the profile (dev, release).