### PR TITLE
Rust: pub use prost::Encode/DecodeError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 include!(concat!(env!("OUT_DIR"), "/helium.rs"));
 pub use blockchain_txn::Txn;
 pub use prost::Message;
+pub use prost::{DecodeError, EncodeError};
+
 #[cfg(feature = "services")]
 pub mod services {
     pub mod router {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,12 @@
 include!(concat!(env!("OUT_DIR"), "/helium.rs"));
 pub use blockchain_txn::Txn;
-pub use prost::Message;
-pub use prost::{DecodeError, EncodeError};
+pub use prost::{DecodeError, EncodeError, Message};
 
 #[cfg(feature = "services")]
 pub mod services {
     pub mod router {
-        pub use crate::router_client::RouterClient as RouterClient;
-        pub use crate::state_channel_client::StateChannelClient as StateChannelClient;
+        pub use crate::router_client::RouterClient;
+        pub use crate::state_channel_client::StateChannelClient;
     }
     pub mod gateway {
         pub use crate::gateway_client::GatewayClient as Client;


### PR DESCRIPTION
prost::Message provides functions which return `Result<_, Encode/DecodeError>`. It's easy to derive application level errors from these errors if we make these types accessible to the client. Otherwise, the client needs to import the right version of `prost` themselves.