### PR TITLE
config service updates

### DIFF
--- a/src/service/gateway.proto
+++ b/src/service/gateway.proto
@@ -4,7 +4,7 @@ package helium;
 
 import "blockchain_state_channel_v1.proto";
 import "blockchain_txn_state_channel_close_v1.proto";
-import "blockchain_txn_vars_v1";
+import "blockchain_txn_vars_v1.proto";
 
 enum close_state {
   close_state_closable = 0;

--- a/src/service/gateway.proto
+++ b/src/service/gateway.proto
@@ -4,6 +4,7 @@ package helium;
 
 import "blockchain_state_channel_v1.proto";
 import "blockchain_txn_state_channel_close_v1.proto";
+import "blockchain_txn_vars_v1";
 
 enum close_state {
   close_state_closable = 0;
@@ -14,16 +15,11 @@ enum close_state {
 
 /* general */
 
-message key_val_v1 {
-  bytes key = 1;
-  bytes val = 2;
-}
 message gateway_config_req_v1 { repeated bytes keys = 1; }
-message gateway_config_resp_v1 { repeated key_val_v1 result = 1; }
+message gateway_config_resp_v1 { repeated blockchain_var_v1 result = 1; }
 
 message gateway_config_update_req_v1 {}
-
-message gateway_config_update_streamed_resp_v1 { repeated key_val_v1 vars = 1; }
+message gateway_config_update_streamed_resp_v1 { repeated bytes keys = 1; }
 
 message gateway_resp_v1 {
   uint64 height = 1;


### PR DESCRIPTION
This proposes that

1. we use blockchain_var_v1 as the encoding type for var key/value pairs. It's already used and includes the type of the value that is encoded in the binary

2. Only stream back keys of changed chain variables. The reasoning is that most chain var changes are not relevant to light gateways, and some (like maker keys or pocv11 region maps) are quite large. Streaming back unused values is not good for bandwidth. With this change the client would still get the keys of values that were changed but would have to come back to ask for the values.