### PR TITLE
add validators grpc req

### DIFF
--- a/src/service/gateway.proto
+++ b/src/service/gateway.proto
@@ -21,6 +21,9 @@ message gateway_config_resp_v1 { repeated blockchain_var_v1 result = 1; }
 message gateway_config_update_req_v1 {}
 message gateway_config_update_streamed_resp_v1 { repeated string keys = 1; }
 
+message gateway_validators_req_v1 { uint32 quantity = 1; }
+message gateway_validators_resp_v1 { repeated routing_address result = 1; }
+
 message gateway_resp_v1 {
   uint64 height = 1;
   bytes signature = 2;
@@ -32,6 +35,7 @@ message gateway_resp_v1 {
     gateway_routing_streamed_resp_v1 routing_streamed_resp = 7;
     gateway_config_resp_v1 config_resp = 8;
     gateway_config_update_streamed_resp_v1 config_update_streamed_resp = 9;
+    gateway_validators_resp_v1 validators_resp = 12;
   }
   uint64 block_time = 10;
   uint64 block_age = 11;
@@ -112,4 +116,5 @@ service gateway {
   rpc config(gateway_config_req_v1) returns (gateway_resp_v1);
   rpc config_update(gateway_config_update_req_v1)
       returns (stream gateway_resp_v1);
+  rpc validators(gateway_validators_req_v1) returns (gateway_resp_v1);
 }


### PR DESCRIPTION
Adds a RPC to retrieve a random selection of validators.  The client can specify the quantity of random validators to return.  The data per validator includes pubkey and routing data.