### PR TITLE
adding ecdh route to local grpc

### DIFF
--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -8,6 +8,9 @@ message pubkey_req {}
 message sign_req { bytes data = 1; }
 message sign_res { bytes signature = 1; }
 
+message ecdh_req { bytes address = 1; }
+message ecdh_res { bytes secret = 1; }
+
 message config_req { repeated string keys = 1; }
 message config_res { repeated config_value values = 1; }
 
@@ -32,6 +35,7 @@ message height_res {
 service api {
   rpc pubkey(pubkey_req) returns (pubkey_res);
   rpc sign(sign_req) returns (sign_res);
+  rpc ecdh(ecdh_req) returns (ecdh_res);
   rpc config(config_req) returns (config_res);
   rpc height(height_req) returns (height_res);
 }


### PR DESCRIPTION
The local grpc service needs to have an ecdh route added to implement a gateway-rs replacement for the ecc-worker