### PR TITLE
Madninja/region reuse

### DIFF
--- a/src/blockchain_state_channel_v1.proto
+++ b/src/blockchain_state_channel_v1.proto
@@ -50,7 +50,7 @@ message blockchain_state_channel_offer_v1 {
   uint32 fcnt = 4;
   bytes hotspot = 5;
   bytes signature = 6;
-  Region region = 7;
+  region region = 7;
   bool req_diff = 8;
 }
 
@@ -58,7 +58,7 @@ message blockchain_state_channel_purchase_v1 {
   blockchain_state_channel_v1 sc = 1;
   bytes hotspot = 2;
   bytes packet_hash = 3;
-  Region region = 4;
+  region region = 4;
   blockchain_state_channel_diff_v1 sc_diff = 5;
 }
 

--- a/src/blockchain_state_channel_v1.proto
+++ b/src/blockchain_state_channel_v1.proto
@@ -3,21 +3,7 @@ syntax = "proto3";
 package helium;
 
 import "packet.proto";
-
-enum Region {
-  US915 = 0;
-  EU868 = 1;
-  EU433 = 2;
-  CN470 = 3;
-  CN779 = 4;
-  AU915 = 5;
-  AS923_1 = 6;
-  KR920 = 7;
-  IN865 = 8;
-  AS923_2 = 9;
-  AS923_3 = 10;
-  AS923_4 = 11;
-}
+import "region.proto";
 
 enum blockchain_state_channel_state_v1 {
   open = 0;
@@ -53,7 +39,7 @@ message blockchain_state_channel_packet_v1 {
   packet packet = 1;
   bytes hotspot = 2;
   bytes signature = 3;
-  Region region = 4;
+  region region = 4;
   uint64 hold_time = 5;
 }
 

--- a/src/region.proto
+++ b/src/region.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package helium;
+
+enum region {
+  US915 = 0;
+  EU868 = 1;
+  EU433 = 2;
+  CN470 = 3;
+  CN779 = 4;
+  AU915 = 5;
+  AS923_1 = 6;
+  KR920 = 7;
+  IN865 = 8;
+  AS923_2 = 9;
+  AS923_3 = 10;
+  AS923_4 = 11;
+}

--- a/src/service/gateway.proto
+++ b/src/service/gateway.proto
@@ -6,6 +6,7 @@ import "blockchain_state_channel_v1.proto";
 import "blockchain_txn_state_channel_close_v1.proto";
 import "blockchain_txn_vars_v1.proto";
 import "blockchain_region_param_v1.proto";
+import "region.proto";
 
 enum close_state {
   close_state_closable = 0;
@@ -27,7 +28,7 @@ message gateway_validators_resp_v1 { repeated routing_address result = 1; }
 
 message gateway_region_params_streamed_resp_v1 {
   bytes address = 1;
-  bytes region = 2;
+  region region = 2;
   blockchain_region_params_v1 params = 3;
 }
 


### PR DESCRIPTION
Lift the region enum used in state channels to its own file and type the region field in stream gateway region responses to use it