### PR TITLE
expose region local call

### DIFF
--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -32,10 +32,14 @@ message height_res {
   keyed_uri gateway = 3;
 }
 
+message region_req {}
+message region_res { int32 region = 1; }
+
 service api {
   rpc pubkey(pubkey_req) returns (pubkey_res);
   rpc sign(sign_req) returns (sign_res);
   rpc ecdh(ecdh_req) returns (ecdh_res);
   rpc config(config_req) returns (config_res);
   rpc height(height_req) returns (height_res);
+  rpc region(region_req) returns (region_res);
 }


### PR DESCRIPTION
This exposes the gateway region as a local call. 

Since Prost/protoc still has issues importing across namespaces we leave the region encoded as i32 and have the client do the right thing :-/
