### PR TITLE
Extend local rpc api with add_gateway_txn

### DIFF
--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -38,8 +38,11 @@ message region_res { int32 region = 1; }
 message add_gateway_req {
   string owner = 1;
   string payer = 2;
-  uint64 amount = 3;
-  uint64 fee = 4;
+  enum staking_mode {
+    dataonly = 0;
+    full = 1;
+    light = 2;
+  }
 }
 
 message add_gateway_res { bytes add_gateway_txn = 1; }

--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -35,14 +35,15 @@ message height_res {
 message region_req {}
 message region_res { int32 region = 1; }
 
+enum staking_mode {
+  dataonly = 0;
+  full = 1;
+  light = 2;
+}
 message add_gateway_req {
   bytes owner = 1;
   bytes payer = 2;
-  enum staking_mode {
-    dataonly = 0;
-    full = 1;
-    light = 2;
-  }
+  staking_mode staking_mode = 3;
 }
 
 message add_gateway_res { bytes add_gateway_txn = 1; }

--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -36,8 +36,8 @@ message region_req {}
 message region_res { int32 region = 1; }
 
 message add_gateway_req {
-  string owner = 1;
-  string payer = 2;
+  bytes owner = 1;
+  bytes payer = 2;
   enum staking_mode {
     dataonly = 0;
     full = 1;

--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -35,6 +35,15 @@ message height_res {
 message region_req {}
 message region_res { int32 region = 1; }
 
+message add_gateway_req {
+  string owner = 1;
+  string payer = 2;
+  uint64 amount = 3;
+  uint64 fee = 4;
+}
+
+message add_gateway_res { bytes add_gateway_txn = 1; }
+
 service api {
   rpc pubkey(pubkey_req) returns (pubkey_res);
   rpc sign(sign_req) returns (sign_res);
@@ -42,4 +51,5 @@ service api {
   rpc config(config_req) returns (config_res);
   rpc height(height_req) returns (height_res);
   rpc region(region_req) returns (region_res);
+  rpc add_gateway(add_gateway_req) returns (add_gateway_res);
 }

--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -35,7 +35,7 @@ message height_res {
 message region_req {}
 message region_res { int32 region = 1; }
 
-enum staking_mode {
+enum gateway_staking_mode {
   dataonly = 0;
   full = 1;
   light = 2;
@@ -43,7 +43,7 @@ enum staking_mode {
 message add_gateway_req {
   bytes owner = 1;
   bytes payer = 2;
-  staking_mode staking_mode = 3;
+  gateway_staking_mode staking_mode = 3;
 }
 
 message add_gateway_res { bytes add_gateway_txn = 1; }


### PR DESCRIPTION
The current hotspots allow for (ebus) rpc communication with the miner to allow generating and returning a signed `blockchain_txn_add_gateway_v1` transaction so the rust light gateway will need to support this functionality as well. This rpc provides a bridge api between the legacy call (which accepts an owner, payer, amount, and fee) and the newer api currently defined in the light gateway where staking fees are immediately known based on the mode of the device and do not need to be calculated from the chain.