### PR TITLE
Define follower service and req/resp

### DIFF
--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -10,24 +10,13 @@ message follower_txn_stream_req_v1 {
   repeated string txn_types = 3;
 }
 
-message follower_txn_streamed_resp_v1 {
+message follower_txn_stream_resp_v1 {
   uint64 height = 1;
-  uint64 epoch = 2;
-  bytes txn_hash = 3;
-  blockchain_txn txn = 4;
-}
-
-message follower_resp_v1 {
-  uint64 height = 1;
-  bytes signature = 2;
-  uint64 block_time = 3;
-  uint64 block_age = 4;
-  oneof event {
-    follower_txn_streamed_resp_v1 txn_event = 5;
-  }
+  bytes txn_hash = 2;
+  blockchain_txn txn = 3;
 }
 
 service follower {
   rpc txn_stream(follower_txn_stream_req_v1)
-      returns (stream follower_resp_v1);
+      returns (stream follower_txn_stream_resp_v1);
 }

--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -5,15 +5,15 @@ package helium;
 import "blockchain_txn.proto";
 
 message follower_txn_stream_req_v1 {
-  uint64 height = 1;
-  bytes hash = 2;
+  optional uint64 height = 1;
+  bytes txn_hash = 2;
   repeated string txn_types = 3;
 }
 
 message follower_txn_streamed_resp_v1 {
   uint64 height = 1;
-  bytes hash = 2;
-  uint64 epoch = 3;
+  uint64 epoch = 2;
+  bytes txn_hash = 3;
   blockchain_txn txn = 4;
 }
 
@@ -29,5 +29,5 @@ message follower_resp_v1 {
 
 service follower {
   rpc txn_stream(follower_txn_stream_req_v1)
-      returns (follower_resp_v1);
+      returns (stream follower_resp_v1);
 }

--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package helium;
+
+import "blockchain_txn.proto";
+
+message follower_txn_stream_req_v1 {
+  uint64 height = 1;
+  bytes hash = 2;
+  repeated string txn_types = 3;
+}
+
+message follower_txn_streamed_resp_v1 {
+  uint64 height = 1;
+  bytes hash = 2;
+  uint64 epoch = 3;
+  blockchain_txn txn = 4;
+}
+
+message follower_resp_v1 {
+  uint64 height = 1;
+  bytes signature = 2;
+  uint64 block_time = 3;
+  uint64 block_age = 4;
+  oneof event {
+    follower_txn_streamed_resp_v1 txn_event = 5;
+  }
+}
+
+service follower {
+  rpc txn_stream(follower_txn_stream_req_v1)
+      returns (follower_resp_v1);
+}


### PR DESCRIPTION
Required proto definition for https://github.com/helium/blockchain-node/pull/139. Defines the proto service for the blockchain-node follower to stream transaction information to consumers for off-chain activities.