### PR TITLE
fix enum order, specify resp msgs

### DIFF
--- a/src/service/transaction.proto
+++ b/src/service/transaction.proto
@@ -5,7 +5,7 @@ import "blockchain_txn.proto";
 
 enum txn_status {
   pending = 0;
-  failed = 2;
+  failed = 1;
 }
 
 message acceptor {
@@ -42,6 +42,6 @@ message txn_query_resp_v1 {
 }
 
 service transaction {
-  rpc submit(txn_submit_req_v1) returns (txn_resp_v1);
-  rpc query(txn_query_req_v1) returns (txn_resp_v1);
+  rpc submit(txn_submit_req_v1) returns (txn_submit_resp_v1);
+  rpc query(txn_query_req_v1) returns (txn_query_resp_v1);
 }


### PR DESCRIPTION
fixes the enum order options following the removal of the `cleared` option and specifies the unary resp types since the transaction service currently doesn't have a generic response envelope.