### PR TITLE
add field to track dialed txn protocol version

### DIFF
--- a/src/blockchain_txn_handler.proto
+++ b/src/blockchain_txn_handler.proto
@@ -21,4 +21,5 @@ message blockchain_txn_info_v1 {
   uint64 height = 4;
   uint32 queue_pos = 5;
   uint32 queue_len = 6;
+  uint32 txn_protocol_version = 7;
 }


### PR DESCRIPTION
This extends `blockchain_txn_info_v1` to include a field to track the negotiation dialler txn protocol between the txn mgr and a CG member.