### PR TITLE
add block timestamp to follower resp

### DIFF
--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -14,6 +14,7 @@ message follower_txn_stream_resp_v1 {
   uint64 height = 1;
   bytes txn_hash = 2;
   blockchain_txn txn = 3;
+  uint64 timestamp = 4;
 }
 
 service follower {


### PR DESCRIPTION
in order to correlate block transactions to real world events for the mobile PoC initial implementation we need to know when the "real world" time of the txn/block occurred.