### PR TITLE
Add rewards_v3 proto

### DIFF
--- a/src/blockchain_txn.proto
+++ b/src/blockchain_txn.proto
@@ -47,6 +47,8 @@ import "blockchain_txn_subnetwork_rewards_v1.proto";
 
 import "blockchain_txn_token_redeem_v1.proto";
 
+import "blockchain_txn_rewards_v3.proto";
+
 message blockchain_txn {
   oneof txn {
     blockchain_txn_add_gateway_v1 add_gateway = 1;
@@ -90,6 +92,7 @@ message blockchain_txn {
     blockchain_txn_update_subnetwork_v1 update_subnetwork = 39;
     blockchain_txn_subnetwork_rewards_v1 subnetwork_rewards = 40;
     blockchain_txn_token_redeem_v1 token_redeem = 41;
+    blockchain_txn_rewards_v3 rewards_v3 = 42;
   }
 }
 

--- a/src/blockchain_txn_rewards_v3.proto
+++ b/src/blockchain_txn_rewards_v3.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package helium;
+
+message blockchain_txn_reward_v3 {
+  bytes account = 1;
+  uint64 amount = 2;
+}
+
+message blockchain_txn_rewards_v3 {
+  uint64 start_epoch = 1;
+  uint64 end_epoch = 2;
+  repeated blockchain_txn_reward_v3 rewards = 3;
+}


### PR DESCRIPTION
Summary
----
This is pretty much the exact same thing as `rewards_v2`, I'm adding this for consistency reasons (since we'll be doing `rewards_v3` transaction separately in blockchain-core. Let me know if this is not required and we want to use the proto for `rewards_v2` for `blockchain_txn_rewards_v3`.

Also please let me know if we should add more stuff here for future proofing.