### PR TITLE
need to make follower request height mandatory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Check formatting
         run: cargo fmt  -- --check
 

--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -5,7 +5,7 @@ package helium;
 import "blockchain_txn.proto";
 
 message follower_txn_stream_req_v1 {
-  optional uint64 height = 1;
+  uint64 height = 1;
   bytes txn_hash = 2;
   repeated string txn_types = 3;
 }


### PR DESCRIPTION
having the height field in a follower stream join request is causing problems so we need to make the field required.