### PR TITLE
Mj/packet router updates

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
                 "src/service/state_channel.proto",
                 "src/service/gateway.proto",
                 "src/service/follower.proto",
+                "src/service/packet_router_service.proto",
             ],
             &["src/"],
         )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use prost::{DecodeError, EncodeError, Message};
 #[cfg(feature = "services")]
 pub mod services {
     pub mod router {
+        pub use crate::packet_router_client::PacketRouterClient;
         pub use crate::router_client::RouterClient;
         pub use crate::state_channel_client::StateChannelClient;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,14 @@ pub use prost::{DecodeError, EncodeError, Message};
 
 #[cfg(feature = "services")]
 pub mod services {
+    // Referenced with helium.packet_router.rs as super::Region
+    pub use crate::Region;
     pub mod router {
-        pub use crate::packet_router_client::PacketRouterClient;
         pub use crate::router_client::RouterClient;
         pub use crate::state_channel_client::StateChannelClient;
+
+        include!(concat!(env!("OUT_DIR"), "/helium.packet_router.rs"));
+        pub use packet_router_client::PacketRouterClient;
     }
     pub mod gateway {
         pub use crate::gateway_client::GatewayClient as Client;

--- a/src/service/packet_router_service.proto
+++ b/src/service/packet_router_service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package helium;
+package helium.packet_router;
 
 import "packet_router.proto";
 


### PR DESCRIPTION
Most significant change is also putting `packet_router_service` under the `helium.packet_router` package name.

My understanding is that protoc treats almost names the same. 
So it couldn't mount the `packet_router` service in the `helium` package when there was already a `helium.packet_router` namespace.