### PR TITLE
Do not use protobuf-src for Windows builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,14 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 
-[build-dependencies]
+# protobuf-src is broken on Windows, and we only need use it to
+# simplify cargo-cross builds.
+[target.'cfg(target_family = "windows")'.build-dependencies]
+tonic-build = {version = "0", optional = true}
+prost-build = "0"
+protoc-bin-vendored = "3"
+
+[target.'cfg(not(target_family = "windows"))'.build-dependencies]
 tonic-build = {version = "0", optional = true}
 prost-build = "0"
 protobuf-src = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,11 @@
 use std::io::Result;
 #[cfg(feature = "services")]
 fn main() -> Result<()> {
+    #[cfg(target_family = "windows")]
+    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+    #[cfg(not(target_family = "windows"))]
     std::env::set_var("PROTOC", protobuf_src::protoc());
+
     tonic_build::configure()
         .build_server(false)
         .type_attribute(".", "#[derive(serde_derive::Serialize)]")
@@ -29,6 +33,9 @@ fn main() -> Result<()> {
 
 #[cfg(not(feature = "services"))]
 fn main() -> Result<()> {
+    #[cfg(target_family = "windows")]
+    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+    #[cfg(not(target_family = "windows"))]
     std::env::set_var("PROTOC", protobuf_src::protoc());
     prost_build::Config::new()
         .type_attribute(".", "#[derive(serde_derive::Serialize)]")


### PR DESCRIPTION
protobuf-src appears to be broken on windows. The problem we're solving by using protobuf-src only applies to Linux, so let's use system protoc for Windows.