### PR TITLE
add streaming gateway info endpoint

### DIFF
--- a/src/service/follower.proto
+++ b/src/service/follower.proto
@@ -24,6 +24,9 @@ message follower_gateway_req_v1 {
   bytes address = 1;
 }
 
+/// Request a stream of all active gateways from the on-chain metadata
+message follower_gateway_stream_req_v1 {}
+
 message follower_gateway_resp_v1 {
   /// The height for at which the ownership was looked up
   uint64 height = 1;
@@ -54,6 +57,8 @@ service follower {
   rpc txn_stream(follower_txn_stream_req_v1)
       returns (stream follower_txn_stream_resp_v1);
   rpc find_gateway(follower_gateway_req_v1) returns (follower_gateway_resp_v1);
+  rpc active_gateways(follower_gateway_stream_req_v1)
+      returns (stream follower_gateway_resp_v1);
   rpc subnetwork_last_reward_height(
       follower_subnetwork_last_reward_height_req_v1)
       returns (follower_subnetwork_last_reward_height_resp_v1);


### PR DESCRIPTION
allow pulling all currently active gateways from the source of truth on recently beaconed gateways asserted to the chain for validation (density calculations initially) by off-chain oracle