### PR TITLE
Add version to entropy

### DIFF
--- a/src/entropy.proto
+++ b/src/entropy.proto
@@ -8,4 +8,6 @@ message entropy {
   /// The start time for the validity of this entropy in seconds since unix
   // epoch
   uint64 timestamp = 2;
+  /// The entro[y version
+  uint32 version = 3;
 }

--- a/src/entropy.proto
+++ b/src/entropy.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package helium;
 
-message entropy {
+message entropy_report_v1 {
   /// The entropy data
   bytes data = 1;
   /// The start time for the validity of this entropy in seconds since unix

--- a/src/entropy.proto
+++ b/src/entropy.proto
@@ -8,6 +8,6 @@ message entropy {
   /// The start time for the validity of this entropy in seconds since unix
   // epoch
   uint64 timestamp = 2;
-  /// The entro[y version
+  /// The entropy version
   uint32 version = 3;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use prost::{DecodeError, EncodeError, Message};
 #[cfg(feature = "services")]
 pub mod services {
     use crate::{
-        BlockchainTokenTypeV1, BlockchainTxn, DataRate, GatewayStakingMode, RoutingAddress,
+        BlockchainTokenTypeV1, BlockchainTxn, DataRate, Entropy, GatewayStakingMode, RoutingAddress,
     };
 
     pub mod router {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use prost::{DecodeError, EncodeError, Message};
 #[cfg(feature = "services")]
 pub mod services {
     use crate::{
-        BlockchainTokenTypeV1, BlockchainTxn, DataRate, Entropy, GatewayStakingMode, RoutingAddress,
+        BlockchainTokenTypeV1, BlockchainTxn, DataRate, GatewayStakingMode, RoutingAddress,
     };
 
     pub mod router {


### PR DESCRIPTION
The version (default to 0) indicates how the entropy is intended to be decoded and used.

The current default version is 0. It indicates that the beacon payload is to be constructed using the sha256 of the remote entropy, remote entropy timestamp, and local entropy in that order.

This is implemented in the `entropy` workspace member of the gateway-rs repo