### PR TITLE
Add config, packet_router protos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,7 @@ const SERVICES: &[&str] = &[
     "src/service/follower.proto",
     "src/service/poc_mobile.proto",
     "src/service/poc_lora.proto",
+    "src/service/packet_router.proto",
 ];
 
 const MESSAGES: &[&str] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub mod services {
     pub mod router {
         pub use crate::router_client::RouterClient;
         pub use crate::state_channel_client::StateChannelClient;
+
+        include!(concat!(env!("OUT_DIR"), "/helium.packet_router.rs"));
+        pub use gateway_client::GatewayClient as PacketRouterClient;
     }
     pub mod gateway {
         pub use crate::gateway_client::GatewayClient as Client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod services {
         pub use crate::state_channel_client::StateChannelClient;
 
         include!(concat!(env!("OUT_DIR"), "/helium.packet_router.rs"));
-        pub use gateway_client::GatewayClient as PacketRouterClient;
+        pub use packet_client::PacketClient as PacketRouterClient;
     }
     pub mod gateway {
         pub use crate::gateway_client::GatewayClient as Client;

--- a/src/service/config.proto
+++ b/src/service/config.proto
@@ -14,20 +14,16 @@ message eui_v1 {
   uint64 dev_eui = 2;
 }
 
-message protocol_packet_router_v1 {
-}
+message protocol_packet_router_v1 {}
 
 message protocol_gwmp_mapping_v1 {
   region region = 1;
   uint32 port = 2;
 }
 
-message protocol_gwmp_v1 {
-  repeated protocol_gwmp_mapping_v1 mapping = 1;
-}
+message protocol_gwmp_v1 { repeated protocol_gwmp_mapping_v1 mapping = 1; }
 
-message protocol_http_roaming_v1 {
-}
+message protocol_http_roaming_v1 {}
 
 message server_v1 {
   bytes host = 1;

--- a/src/service/config.proto
+++ b/src/service/config.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package helium.config;
+
+message devaddr_range_v1 {
+  uint64 start_addr = 1;
+  uint64 end_addr = 2;
+}
+
+message eui_v1 {
+  uint64 app_eui = 1;
+  uint64 dev_eui = 2;
+}
+
+message protocol_router {
+  bytes ip = 1;
+  uint32 port = 2;
+}
+
+message protocol_gwmp {
+  bytes ip = 1;
+  uint32 port = 2;
+}
+
+message protocol_http_roaming {
+  bytes ip = 1;
+  uint32 port = 2;
+}
+
+message route_v1 {
+  uint64 net_id = 1;
+  repeated devaddr_range_v1 devaddr_ranges = 2;
+  repeated eui_v1 euis = 3;
+  uint64 oui = 4;
+  oneof protocol {
+    protocol_router router = 5;
+    protocol_gwmp gwmp = 6;
+    protocol_http_roaming http_roaming = 7;
+  }
+}
+
+message routes_req_v1 {}
+
+message routes_res_v1 { repeated route_v1 routes = 1; }
+
+service config_service {
+  rpc route_updates(routes_req_v1) returns (stream routes_res_v1);
+}

--- a/src/service/config.proto
+++ b/src/service/config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package helium.config;
 
+import "region.proto";
+
 message devaddr_range_v1 {
   uint64 start_addr = 1;
   uint64 end_addr = 2;
@@ -12,19 +14,29 @@ message eui_v1 {
   uint64 dev_eui = 2;
 }
 
-message protocol_router {
-  bytes ip = 1;
+message protocol_packet_router_v1 {
+}
+
+message protocol_gwmp_mapping_v1 {
+  region region = 1;
   uint32 port = 2;
 }
 
-message protocol_gwmp {
-  bytes ip = 1;
-  uint32 port = 2;
+message protocol_gwmp_v1 {
+  repeated protocol_gwmp_mapping_v1 mapping = 1;
 }
 
-message protocol_http_roaming {
-  bytes ip = 1;
+message protocol_http_roaming_v1 {
+}
+
+message server_v1 {
+  bytes host = 1;
   uint32 port = 2;
+  oneof protocol {
+    protocol_packet_router_v1 packet_router = 3;
+    protocol_gwmp_v1 gwmp = 4;
+    protocol_http_roaming_v1 http_roaming = 5;
+  }
 }
 
 message route_v1 {
@@ -32,11 +44,7 @@ message route_v1 {
   repeated devaddr_range_v1 devaddr_ranges = 2;
   repeated eui_v1 euis = 3;
   uint64 oui = 4;
-  oneof protocol {
-    protocol_router router = 5;
-    protocol_gwmp gwmp = 6;
-    protocol_http_roaming http_roaming = 7;
-  }
+  server_v1 server = 5;
 }
 
 message routes_req_v1 {}

--- a/src/service/packet_router.proto
+++ b/src/service/packet_router.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package helium.packet_router;
+
+import "region.proto";
+import "data_rate.proto";
+
+message packet_router_packet_up_v1 {
+  bytes payload = 1;
+  uint64 timestamp = 2;
+  uint32 rssi = 3;
+  // Frequency in hz
+  uint32 frequency = 4;
+  data_rate datarate = 5;
+  float snr = 6;
+  region region = 7;
+  uint64 hold_time = 8;
+  bytes gateway = 9;
+  bytes signature = 10;
+}
+
+message packet_router_packet_report_v1 {
+  uint64 gateway_timestamp_ms = 1;
+  uint32 oui = 2;
+  uint64 net_id = 3;
+  // LoRa signal strength
+  uint32 rssi = 4;
+  // Frequency in hz
+  uint32 frequency = 5;
+  float snr = 6;
+  data_rate datarate = 7;
+  region region = 8;
+  bytes gateway = 9;
+  // Hash of `payload` within `message packet`
+  bytes payload_hash = 10;
+}
+
+message window_v1 {
+  uint64 timestamp = 1;
+  // Frequency in hz
+  uint32 frequency = 2;
+  data_rate datarate = 3;
+}
+
+message packet_router_packet_down_v1 {
+  bytes payload = 1;
+  window_v1 rx1 = 2;
+  window_v1 rx2 = 3;
+}
+
+service gateway {
+  rpc send_packet(stream packet_router_packet_up_v1)
+      returns (stream packet_router_packet_down_v1);
+}

--- a/src/service/packet_router.proto
+++ b/src/service/packet_router.proto
@@ -48,7 +48,7 @@ message packet_router_packet_down_v1 {
   window_v1 rx2 = 3;
 }
 
-service gateway {
-  rpc send_packet(stream packet_router_packet_up_v1)
+service packet {
+  rpc route(stream packet_router_packet_up_v1)
       returns (stream packet_router_packet_down_v1);
 }


### PR DESCRIPTION
This supersedes https://github.com/helium/proto/pull/157 which was too convoluted due to many `merge master`, etc.

Add:
- `package helium.config`
- `package helium.packet_router`
