### PR TITLE
add invalid enum to cover stale reports

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -25,6 +25,7 @@ enum invalid_reason {
   max_distance_exceeded = 12;
   invalid_frequency = 13;
   self_witness = 14;
+  stale = 15;
 }
 
 // beacon report as submitted by gateway to ingestor


### PR DESCRIPTION
Add support for an error enum to cover beacon and witness reports which end up getting purged due to being stale.  This will be outputted with the invalid report by the verifier