### PR TITLE
Change poc_mobile share to heartbeat

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -135,8 +135,8 @@ message owner_share {
 message owner_shares { repeated owner_share shares = 1; }
 
 enum file_type {
-  heartbeat = 0;
-  speedtest = 1;
+  file_type_heartbeat = 0;
+  file_type_speedtest = 1;
 }
 
 enum cell_type {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -77,11 +77,10 @@ message heartbeat {
 
 enum heartbeat_validity {
   heartbeat_validity_valid = 0;
-  heartbeat_validity_decode_failed = 1;
-  heartbeat_validity_gateway_owner_not_found = 2;
-  heartbeat_validity_heartbeat_outside_range = 3;
-  heartbeat_validity_bad_cbsd_id = 4;
-  heartbeat_validity_not_operational = 5;
+  heartbeat_validity_gateway_owner_not_found = 1;
+  heartbeat_validity_heartbeat_outside_range = 2;
+  heartbeat_validity_bad_cbsd_id = 3;
+  heartbeat_validity_not_operational = 4;
 }
 
 message speedtest_avg {
@@ -135,8 +134,8 @@ message owner_share {
 message owner_shares { repeated owner_share shares = 1; }
 
 enum file_type {
-  file_type_heartbeat = 0;
-  file_type_speedtest = 1;
+  heartbeat = 0;
+  speedtest = 1;
 }
 
 enum cell_type {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -134,8 +134,8 @@ message owner_share {
 message owner_shares { repeated owner_share shares = 1; }
 
 enum file_type {
-  heartbeat = 0;
-  speedtest = 1;
+  file_type_heartbeat = 0;
+  file_type_speedtest = 1;
 }
 
 enum cell_type {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -66,24 +66,22 @@ message file_info {
 
 message processed_files { repeated file_info files = 1; }
 
-message share {
+message heartbeat {
   string cbsd_id = 1;
   bytes pub_key = 2;
   uint64 weight = 3;
   uint64 timestamp = 4;
   cell_type cell_type = 5;
-  share_validity validity = 6;
+  heartbeat_validity validity = 6;
 }
 
-message shares { repeated share shares = 1; }
-
-enum share_validity {
-  share_validity_valid = 0;
-  share_validity_decode_failed = 1;
-  share_validity_gateway_owner_not_found = 2;
-  share_validity_heartbeat_outside_range = 3;
-  share_validity_bad_cbsd_id = 4;
-  share_validity_not_operational = 5;
+enum heartbeat_validity {
+  heartbeat_validity_valid = 0;
+  heartbeat_validity_decode_failed = 1;
+  heartbeat_validity_gateway_owner_not_found = 2;
+  heartbeat_validity_heartbeat_outside_range = 3;
+  heartbeat_validity_bad_cbsd_id = 4;
+  heartbeat_validity_not_operational = 5;
 }
 
 message speedtest_avg {


### PR DESCRIPTION
Current protobuf poc_mobile::share really represents a valid or invalid heartbeat so changing the name and removing the wrapper(shares).