### PR TITLE
Add reward multiplier to speedtest_avg

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -94,6 +94,7 @@ message speedtest_avg {
   repeated speedtest speedtests = 6;
   /// Unix timestamp (seconds since 1970) of when the average was calculated
   uint64 timestamp = 7;
+  float reward_multiplier = 8;
 }
 
 message speedtest {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -69,7 +69,7 @@ message processed_files { repeated file_info files = 1; }
 message heartbeat {
   string cbsd_id = 1;
   bytes pub_key = 2;
-  uint64 weight = 3;
+  float reward_multiplier = 3;
   uint64 timestamp = 4;
   cell_type cell_type = 5;
   heartbeat_validity validity = 6;


### PR DESCRIPTION
Based on a brief discussion with @meowshka, float seems like the most appropriate value for the multiplier. 