### PR TITLE
add scaling factor map proto

### DIFF
--- a/src/scaling_factors.proto
+++ b/src/scaling_factors.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package helium;
+
+message scaling_factors { map<string, double> hex_to_sf = 1; }


### PR DESCRIPTION
adds a message type for the off-chain oracle hex density scaling factor server to write out its results each interval to a reporting bucket for auditability