### PR TITLE
Change subnetwork reward to give out reward percentage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ prost = "0"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+rust_decimal = {version = "1", optional = true}
 
 [build-dependencies]
 # simplify builds (including for cross builds) by using a vendored protoc

--- a/src/blockchain_txn_subnetwork_rewards_v1.proto
+++ b/src/blockchain_txn_subnetwork_rewards_v1.proto
@@ -5,15 +5,20 @@ import "blockchain_token_type_v1.proto";
 
 message subnetwork_reward {
   bytes account = 1;
+  uint64 amount = 2;
+}
+
+message subnetwork_reward_share {
+  bytes account = 1;
   /// Value between (0, 1] indicating the percentage of rewards to be given to
   /// the given account.
   double reward_percent = 2;
 }
 
-message subnetwork_rewards {
+message subnetwork_reward_shares {
   uint64 start_epoch = 1;
   uint64 end_epoch = 2;
-  repeated subnetwork_reward rewards = 3;
+  repeated subnetwork_reward_shares rewards = 3;
 }
 
 message blockchain_txn_subnetwork_rewards_v1 {

--- a/src/blockchain_txn_subnetwork_rewards_v1.proto
+++ b/src/blockchain_txn_subnetwork_rewards_v1.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package helium;
 
+import "decimal.proto";
 import "blockchain_token_type_v1.proto";
 
 message subnetwork_reward {
@@ -12,7 +13,7 @@ message subnetwork_reward_share {
   bytes account = 1;
   /// Value between (0, 1] indicating the percentage of rewards to be given to
   /// the given account.
-  double reward_percent = 2;
+  decimal reward_percent = 2;
 }
 
 message subnetwork_reward_shares {

--- a/src/blockchain_txn_subnetwork_rewards_v1.proto
+++ b/src/blockchain_txn_subnetwork_rewards_v1.proto
@@ -18,7 +18,7 @@ message subnetwork_reward_share {
 message subnetwork_reward_shares {
   uint64 start_epoch = 1;
   uint64 end_epoch = 2;
-  repeated subnetwork_reward_shares rewards = 3;
+  repeated subnetwork_reward_share reward_shares = 3;
 }
 
 message blockchain_txn_subnetwork_rewards_v1 {

--- a/src/blockchain_txn_subnetwork_rewards_v1.proto
+++ b/src/blockchain_txn_subnetwork_rewards_v1.proto
@@ -5,7 +5,9 @@ import "blockchain_token_type_v1.proto";
 
 message subnetwork_reward {
   bytes account = 1;
-  uint64 amount = 2;
+  /// Value between (0, 1] indicating the percentage of rewards to be given to
+  /// the given account.
+  double reward_percent = 2;
 }
 
 message subnetwork_rewards {

--- a/src/decimal.proto
+++ b/src/decimal.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package helium;
+
+/// rust_decimal serializes to an array of 16 bytes. We encode that as two uint64s
+/// taking the bytes in big-endian (arbitrarily chosen).
+message decimal {
+  uint64 hi = 1;
+  uint64 lo = 2;
+}

--- a/src/decimal.proto
+++ b/src/decimal.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package helium;
 
-/// rust_decimal serializes to an array of 16 bytes. We encode that as two uint64s
-/// taking the bytes in big-endian (arbitrarily chosen).
+/// rust_decimal serializes to an array of 16 bytes. We encode that as two
+/// uint64s taking the bytes in big-endian (arbitrarily chosen).
 message decimal {
   uint64 hi = 1;
   uint64 lo = 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,3 +180,26 @@ impl std::fmt::Display for Region {
         }
     }
 }
+
+#[cfg(feature = "rust_decimal")]
+mod rust_decimal_impls {
+    use super::*;
+
+    impl From<Decimal> for rust_decimal::Decimal {
+        fn from(dec: Decimal) -> Self {
+            let [a, b, c, d, e, f, g, h] = dec.lo.to_be_bytes();
+            let [i, j, k, l, m, n, o, p] = dec.hi.to_be_bytes();
+            Self::deserialize([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p])
+        }
+    }
+
+    impl From<rust_decimal::Decimal> for Decimal {
+        fn from(dec: rust_decimal::Decimal) -> Self {
+            let [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p] = dec.serialize();
+            Self {
+                lo: u64::from_be_bytes([a, b, c, d, e, f, g, h]),
+                hi: u64::from_be_bytes([i, j, k, l, m, n, o, p]),
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm fairly certain that a double float is suitable enough to describe reward period percentages