### PR TITLE
scan_hash with mapper_gps

### DIFF
--- a/src/mapper.proto
+++ b/src/mapper.proto
@@ -55,6 +55,9 @@ message mapper_attach_v1 {
 
 message mapper_gps {
   oneof version { mapper_gps_v1 gps_v1 = 1; }
+  // Optionally, the hash of a mapper_scan may be included.
+  // This data is NOT signed over and shall be removed when verifying signature.
+  repeated bytes scan_hash = 2;
 }
 
 message mapper_gps_v1 {


### PR DESCRIPTION
This allows the Mapper to add a `scan_hash` with a GPS payload sent over LoRaWAN. This `scan_hash` is added by the application space and is therefore _not_ signed by the Trustzone application.

The affiliated `scan_event` is eventually uploaded when the Mapper has a TCP connection (via WiFi or LoRa) and the event itself is signed by Trustzone and contains a `mapper_gps_v1`. Therefore, there is not much security lost in not signing over the hash.