### PR TITLE
convert wire-format of scaling factor to string

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -86,7 +86,8 @@ message lora_valid_beacon_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  float hex_scale = 3;
+  // string encoding of a reward multiplier between 0.0 and 1.0
+  string hex_scale = 3;
   lora_beacon_report_req_v1 report = 4;
 }
 
@@ -95,7 +96,8 @@ message lora_valid_witness_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  float hex_scale = 3;
+  // string encoding of a reward multiplier between 0.0 and 1.0
+  string hex_scale = 3;
   lora_witness_report_req_v1 report = 4;
 }
 


### PR DESCRIPTION
within the application code, to avoid imprecise conversions for rewards we use the Decimal implementation defined in `rust_decimal`; the string format of the type when serialized over the wire is likely to lead to more precise interpretations of the intended value across different systems/architectures than converting to and from floating point types.