### PR TITLE
convert scaling factors to integers

### DIFF
--- a/src/scaling_factors.proto
+++ b/src/scaling_factors.proto
@@ -2,4 +2,6 @@ syntax = "proto3";
 
 package helium;
 
-message scaling_factors { map<string, double> hex_to_sf = 1; }
+// map of string h3 res 12 hex address to reward scaling factor
+// as an integer representation of the 2-point precision decimal percent
+message scaling_factors { map<string, uint32> hex_to_sf = 1; }

--- a/src/scaling_factors.proto
+++ b/src/scaling_factors.proto
@@ -3,5 +3,6 @@ syntax = "proto3";
 package helium;
 
 // map of string h3 res 12 hex address to reward scaling factor
-// as an integer representation of the 2-point precision decimal percent
+// as an integer representation of the 4-point precision decimal multiplier
+// Ex: 5015 = 0.5015
 message scaling_factors { map<string, uint32> hex_to_sf = 1; }

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -86,7 +86,8 @@ message lora_valid_beacon_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  // integer representation of a 2-point precision decimal percent multiplier
+  // integer representation of a 4-point precision decimal multiplier
+  // ex: 5015 == 0.5015
   uint32 hex_scale = 3;
   lora_beacon_report_req_v1 report = 4;
 }
@@ -96,7 +97,8 @@ message lora_valid_witness_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  // integer representation of a 2-point precision decimal percent multiplier
+  // integer representation of a 4-point precision decimal multiplier
+  // ex: 5015 == 0.5015
   uint32 hex_scale = 3;
   lora_witness_report_req_v1 report = 4;
 }

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -86,8 +86,8 @@ message lora_valid_beacon_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  // string encoding of a reward multiplier between 0.0 and 1.0
-  string hex_scale = 3;
+  // integer representation of a 2-point precision decimal percent multiplier
+  uint32 hex_scale = 3;
   lora_beacon_report_req_v1 report = 4;
 }
 
@@ -96,8 +96,8 @@ message lora_valid_witness_report_v1 {
   // Timestamp at ingest in millis since unix epoch
   uint64 received_timestamp = 1;
   string location = 2;
-  // string encoding of a reward multiplier between 0.0 and 1.0
-  string hex_scale = 3;
+  // integer representation of a 2-point precision decimal percent multiplier
+  uint32 hex_scale = 3;
   lora_witness_report_req_v1 report = 4;
 }
 


### PR DESCRIPTION
to avoid precision conflicts across architectures, represent these scaling factor percentages as integers; in practice they are a 2-decimal precision percentage multiplier.