### PR TITLE
add reward unit to beacon and witness reports

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -90,6 +90,9 @@ message lora_valid_beacon_report_v1 {
   // ex: 5015 == 0.5015
   uint32 hex_scale = 3;
   lora_beacon_report_req_v1 report = 4;
+  // integer representation of a 4-point precision decimal multiplier
+  // based on the number of witnesses to a poc event
+  uint32 reward_unit = 5;
 }
 
 // tagged valid witness report produced by the verifier
@@ -101,6 +104,9 @@ message lora_valid_witness_report_v1 {
   // ex: 5015 == 0.5015
   uint32 hex_scale = 3;
   lora_witness_report_req_v1 report = 4;
+  // integer representation of a 4-point precision decimal multiplier
+  // based on the number of witnesses to a poc event
+  uint32 reward_unit = 5;
 }
 
 // tagged invalid beacon report produced by the verifier


### PR DESCRIPTION
necessary for moving the calculation of the reward unit (a multiplier of iot reward shares) currently encapsulated within the Iot Injector but being moved to the IoT Verifier. Rather than multiplying the `hex_scale` and `reward_unit` values within the verifier and sending the values as a single field in the outgoing valid reports for ease of upgrading the existing proto messages as well as additional transparency they are sent as separate fields.