### PR TITLE
adding gateway reward shares message for iot subnetwork rewards

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -136,6 +136,21 @@ message lora_valid_poc_v1 {
   repeated lora_valid_witness_report_v1 witness_reports = 3;
 }
 
+// iot per-gateway reward share for a given reward period
+// for PoC coverage events provided between the start and end timestamps
+message gateway_reward_share {
+  /// Public key of the hotspot
+  bytes hotspot_key = 1;
+  /// Amount credited to the hotspot for beaconing
+  uint64 beacon_amount = 2;
+  /// Amount credited to the hotspot for witnessing
+  uint64 witness_amount = 3;
+  /// Unix timestamp in seconds of the start of the reward period
+  uint64 start_period = 4;
+  /// Unix timestamp in seconds of the end of the reward period
+  uint64 end_period = 5;
+}
+
 service poc_lora {
   rpc submit_lora_beacon(lora_beacon_report_req_v1)
       returns (lora_beacon_report_resp_v1);


### PR DESCRIPTION
the included new message type in the iot poc service mirrors the `radio_reward_shares` message type in the mobile verifier for aggregating all rewards accumulated by a given hotspot within a reward calculation period which can then be collected under a reward manifest for the given period and emitted to an iot reward indexer for issuing IoT subnetwork rewards to the hotspot as part of off-chain poc rewards.

the structure of the message is largely the same except the atomic unit of reward accumulation for the iot subnetwork is the lorawan gateway, whereas the mobile subnetwork's is the cbrs radio.