### PR TITLE
add missing scaling factor poc invalid reason

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -26,6 +26,7 @@ enum invalid_reason {
   invalid_frequency = 13;
   self_witness = 14;
   stale = 15;
+  scaling_factor_not_found = 16;
 }
 
 // beacon report as submitted by gateway to ingestor


### PR DESCRIPTION
This change is required as a pre-requisite to IoT PoC witness and beacon validation including returning a valid scaling factor as part of validation.