### PR TITLE
add devaddr rpc for route

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -184,8 +184,9 @@ message route_delete_req_v1 {
 }
 
 enum route_euis_action_v1 {
-  add = 0;
-  remove = 1;
+  add_euis = 0;
+  remove_euis = 1;
+  update_euis = 2;
 }
 
 message route_euis_req_v1 {
@@ -201,6 +202,27 @@ message route_euis_res_v1 {
   string id = 1;
   route_euis_action_v1 action = 2;
   repeated eui_v1 euis = 3;
+}
+
+enum route_devaddrs_action_v1 {
+  add_devaddrs = 0;
+  remove_devaddrs = 1;
+  update_devaddrs = 2;
+}
+
+message route_devaddrs_req_v1 {
+  string id = 1;
+  route_devaddrs_action_v1 action = 2;
+  repeated devaddr_range_v1 devaddr_ranges = 3;
+  uint64 timestamp = 4;
+  bytes signer = 5;
+  bytes signature = 6;
+}
+
+message route_devaddrs_res_v1 {
+  string id = 1;
+  route_devaddrs_action_v1 action = 2;
+  repeated devaddr_range_v1 devaddr_ranges = 3;
 }
 
 message route_stream_req_v1 {
@@ -311,8 +333,10 @@ service route {
   rpc update(route_update_req_v1) returns (route_v1);
   // Delete Route for an Org (auth delegate_keys/owner/admin)
   rpc delete (route_delete_req_v1) returns (route_v1);
-  // Add / Remove EUIs from a Route (auth delegate_keys/owner/admin)
+  // Add / Remove / Update EUIs from a Route (auth delegate_keys/owner/admin)
   rpc euis(route_euis_req_v1) returns (route_euis_res_v1);
+  // Add / Remove/ Update Devaddr Ranges from a Route (auth delegate_keys/owner/admin)
+  rpc devaddrs(route_devaddrs_req_v1) returns (route_devaddrs_res_v1);
   // Stream Routes update (auth admin only)
   rpc stream(route_stream_req_v1) returns (stream route_stream_res_v1);
 }


### PR DESCRIPTION
updated action enum values to be have the type

you can't have enums in a namespace with conflicting values.

`action_v1` has create/update/delete for streaming config information to subscribers, which means we can't use any of those words as enum values anywhere else.