### PR TITLE
add devaddr_ranges field to org_v1

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -8,12 +8,29 @@ import "region.proto";
 // Message Definitions
 // ------------------------------------------------------------------
 
+// == Field Notes ==
+//
 // - Every message including `signature` will need to be signed over the all
 //    message, with the `signature` field set to an empty value.
+//
 // - Every `timestamp` is in millseconds
+//
 // - Every key called `owner`, `payer`, `signer` and `delegate_keys` are binary
 //    encoded public keys, Rust encoding example here:
 //    https://github.com/helium/helium-crypto-rs/blob/main/src/public_key.rs#L347-L354
+//
+// == DevAddrs ==
+//
+// - `devaddr_ranges` are inclusive on both sides, `start_addr` and `end_addr`.
+//
+// - `org_res_v1.devaddr_ranges` provides the ranges of DevAddrs available to
+//    any `route_v1` under an Org.
+//
+// - `route_v1.devaddr_ranges` provides the ranges of DevAddrs that should go to
+//    this specific Route. This ranges must always fall within the
+//    `devaddr_ranges` of the owning org.
+
+
 
 enum action_v1 {
   create = 0;


### PR DESCRIPTION
A "Helium" org would have 1-n ranges within the Helium NetID. "Roaming" orgs would have a single range that spans their entire NetID.

Any Routes created or updated will have their devaddr ranges checked against the orgs list of devaddr range restrictions.

In thinking about calling this field "restrictions", there could be more fields for an org that come along and "restrict" their ability to do various things. In other messages, devaddr_ranges are named the same, and the intent can be easily inferred through the context of the message.