### PR TITLE
add missing region params message

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ const MESSAGES: &[&str] = &[
     "src/region.proto",
     "src/mapper.proto",
     "src/reward_manifest.proto",
+    "src/blockchain_region_param_v1.proto",
 ];
 
 #[cfg(feature = "services")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,13 @@ pub use prost::{DecodeError, EncodeError, Message};
 #[cfg(feature = "services")]
 pub mod services {
     use crate::{
-        BlockchainTokenTypeV1, BlockchainTxn, DataRate, GatewayStakingMode, MapperAttach, Region,
-        RoutingAddress,
+        BlockchainRegionParamsV1, BlockchainTokenTypeV1, BlockchainTxn, DataRate,
+        GatewayStakingMode, MapperAttach, Region, RoutingAddress,
     };
 
     pub mod iot_config {
         include!(concat!(env!("OUT_DIR"), "/helium.iot_config.rs"));
+        pub use gateway_server::{Gateway, GatewayServer};
         pub use org_client as config_org_client;
         pub use org_server::{Org, OrgServer};
         pub use route_client as config_route_client;


### PR DESCRIPTION
This update to the lib.rs and build.rs are needed to allow the generated code to properly import the struct type of the region params newly added to the iot_config service and to do deserialization of the type.