### PR TITLE
support generic error as invalid reason

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -27,6 +27,7 @@ enum invalid_reason {
   self_witness = 14;
   stale = 15;
   scaling_factor_not_found = 16;
+  unknown_error = 17;
 }
 
 // beacon report as submitted by gateway to ingestor


### PR DESCRIPTION
Adds general error to be used as the invalid reason for a witness or beacon should verification hit an unexpected error and no specific verification fail reason can be determined