### PR TITLE
annotate deprecate nonce field checks

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -47,7 +47,8 @@ message org_v1 {
   bytes payer = 3;
   // List of keys allowed some specific actions, see services.
   repeated bytes delegate_keys = 4;
-  uint64 nonce = 5;
+  // Incremental int for updates (DEPRECATED)
+  uint64 nonce = 5; // use req timestamps to validate order/avoid replay
 }
 
 // Device address range, ex: 16#00000001 to 16#0000000A
@@ -115,8 +116,8 @@ message route_v1 {
   server_v1 server = 6;
   // Number of packet copies bought by this route
   uint32 max_copies = 7;
-  // Incremental int for updates
-  uint64 nonce = 8;
+  // Incremental int for updates (DEPRECATED)
+  uint64 nonce = 8; // use req timestamps to validate order/avoid replay
 }
 
 // ------------------------------------------------------------------


### PR DESCRIPTION
For the time being, we have decided to deprecate checking the route and org nonce is incremented on updates in favor of exclusively validating the timestamp supplied in the signed request is within the configured ttl window _and_ is ordered monotonically increasing from the previous update to the record.

Annotate the nonce field in the proto repo to ensure that consumers of the proto repo are aware the field is no longer used.