### PR TITLE
derive deser for region (and others)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,10 @@ fn main() -> Result<()> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .type_attribute(".", "#[derive(serde_derive::Serialize)]")
+        .type_attribute(
+            ".",
+            "#[derive(serde_derive::Serialize, serde_derive::Deserialize)]",
+        )
         .type_attribute(".helium.config", "#[derive(serde_derive::Deserialize)]")
         .compile(
             &MESSAGES
@@ -49,7 +52,10 @@ fn main() -> Result<()> {
 fn main() -> Result<()> {
     std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
     prost_build::Config::new()
-        .type_attribute(".", "#[derive(serde_derive::Serialize)]")
+        .type_attribute(
+            ".",
+            "#[derive(serde_derive::Serialize, serde_derive::Deserialize)]",
+        )
         .compile_protos(MESSAGES, &["src"])?;
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,6 @@ fn main() -> Result<()> {
             ".",
             "#[derive(serde_derive::Serialize, serde_derive::Deserialize)]",
         )
-        .type_attribute(".helium.config", "#[derive(serde_derive::Deserialize)]")
         .compile(
             &MESSAGES
                 .iter()


### PR DESCRIPTION
implement deserialize alongside serialize for the core proto messages used throughout various projects to simplify and consolidate definitions of the commonly used protos into the proto repo and avoid having to re-implement them or else wrap them in new types to allow defining common traits like (de)serialize