### PR TITLE
Add comment for becon report tx_power

### DIFF
--- a/src/service/poc_iot.proto
+++ b/src/service/poc_iot.proto
@@ -40,6 +40,8 @@ message iot_beacon_report_req_v1 {
   uint64 frequency = 6;
   int32 channel = 7;
   data_rate datarate = 8;
+  // The Conducted transmit power in ddbm. This is _not_ adjusted with the
+  // asserted gain of the gateway
   int32 tx_power = 9;
   // Timestamp of beacon transmit in nanos since unix epoch
   uint64 timestamp = 10;


### PR DESCRIPTION
The reported tx_power does _not_ include the asserted gain. The verification will need to take the asserted gain into account.