### PR TITLE
config api for loading region info into config svc

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -370,7 +370,7 @@ message load_region_req_v1 {
   blockchain_region_params_v1 params = 2;
   // Gzip-compressed file content from converting region geojson to a list of h3
   // indexes
-  bytes hex_indexes = 3;
+  optional bytes hex_indexes = 3;
   bytes signature = 4;
 }
 

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -365,6 +365,17 @@ message gateway_region_params_res_v1 {
   bytes signature = 4;
 }
 
+message load_region_req_v1 {
+  region region = 1;
+  blockchain_region_params_v1 params = 2;
+  // Gzip-compressed file content from converting region geojson to a list of h3
+  // indexes
+  bytes hex_indexes = 3;
+  bytes signature = 4;
+}
+
+message load_region_res_v1 {}
+
 // ------------------------------------------------------------------
 // Service Definitions
 // ------------------------------------------------------------------
@@ -425,7 +436,10 @@ service session_key_filter {
 
 service gateway {
   // Return the region params for the asserted location of the signed gateway
-  // address
+  // address (no auth, but signature validated)
   rpc region_params(gateway_region_params_req_v1)
       returns (gateway_region_params_res_v1);
+  // Load params and cell indexes for a region into the config service (auth
+  // admin only)
+  rpc load_region(load_region_req_v1) returns (load_region_res_v1);
 }


### PR DESCRIPTION
Adds an admin RPC to the iot_config proto allowing an admin user (signing the request messages with the authorized admin keypair) to load the contents of a `Region.res7.h3idx` file output by the lorawan-h3 `lw-generator`, as well as a collection of `blockchain_region_params_v1` into the appropriate region within the config service.