### PR TITLE
make region index file non-optional

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -337,16 +337,16 @@ message gateway_region_params_res_v1 {
   bytes signature = 4;
 }
 
-message load_region_req_v1 {
+message gateway_load_region_req_v1 {
   region region = 1;
   blockchain_region_params_v1 params = 2;
   // Gzip-compressed file content from converting region geojson to a list of h3
   // indexes
-  optional bytes hex_indexes = 3;
+  bytes hex_indexes = 3;
   bytes signature = 4;
 }
 
-message load_region_res_v1 {}
+message gateway_load_region_res_v1 {}
 
 // ------------------------------------------------------------------
 // Service Definitions
@@ -426,5 +426,6 @@ service gateway {
       returns (gateway_region_params_res_v1);
   // Load params and cell indexes for a region into the config service (auth
   // admin only)
-  rpc load_region(load_region_req_v1) returns (load_region_res_v1);
+  rpc load_region(gateway_load_region_req_v1)
+      returns (gateway_load_region_res_v1);
 }


### PR DESCRIPTION
Renaming the messages for the gateway load region as well to conform to the convention used by the other service req/res messages