### PR TITLE
Remove protoc dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,5 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 
 [build-dependencies]
-# simplify builds (including for cross builds) by using a vendored protoc
-protoc-bin-vendored = "3"
 tonic-build = {version = "0", optional = true}
 prost-build = "0"

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@
 ![erlang workflow](https://github.com/helium/proto/actions/workflows/erlang.yml/badge.svg)
 ![cpp workflow](https://github.com/helium/proto/actions/workflows/cpp.yml/badge.svg)
 
+Using this repository requires `protobuf`'s `protoc` to be installed. The
+package to be installed differs per host platform.
+
 ## Contributing
 
 - Protobuf `message` definitions live in either:
-  + `src/service/*.proto` if only used in gRPC service definitions, or
-  + `src/*.proto` if used by service-free code or shared across gRPC services
+  - `src/service/*.proto` if only used in gRPC service definitions, or
+  - `src/*.proto` if used by service-free code or shared across gRPC services
 - Avoid `float` in Protobufs because representations differ across hardware architectures
-  + There are many floating point representations from IEEE, plus others
-  + i.e., some range of interior digits are random per float spec
+  - There are many floating point representations from IEEE, plus others
+  - i.e., some range of interior digits are random per float spec
 - Frequency should use `uint32` and should be in Hz
 - rssi or signal is always negative, thus use `sint32` and is in deci-dbm (aka `ddbm`) which is `dbm * 10`
 - snr is signal-to-noise ratio and should be `uint32`
 - Fetch and share time in nanos, then truncate to appropriate granularity as needed
-  + e.g., get from OS in nanos
+  - e.g., get from OS in nanos
 - Reject any PR unless units are documented inline within Protobuf definition
 - Document units of fields
-- When exceptions to the above occur, please explain *why* within comments
+- When exceptions to the above occur, please explain _why_ within comments

--- a/build.rs
+++ b/build.rs
@@ -40,8 +40,6 @@ macro_rules! config {
 
 #[cfg(feature = "services")]
 fn main() -> Result<()> {
-    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
-
     config!(tonic_build::configure())
         .build_server(true)
         .build_client(true)
@@ -58,7 +56,6 @@ fn main() -> Result<()> {
 
 #[cfg(not(feature = "services"))]
 fn main() -> Result<()> {
-    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
     config!(prost_build::Config::new()).compile_protos(MESSAGES, &["src"])?;
     Ok(())
 }


### PR DESCRIPTION
This removes the vendored protoc dependency and rely on the host platform to have the right version installed.

The vendored protoc were added to suppport `cross` docker images that did not have the ability to add protoc to the image. This is now possible in cross.

This is an alternate solution to #272 