### PR TITLE
first revision of mobile config service proto

### DIFF
--- a/build-cpp.sh
+++ b/build-cpp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SERVICES=$(echo src/service/{iot_config,downlink,follower,gateway,local,packet_router,poc_lora,poc_mobile,router,state_channel,transaction}.proto)
+SERVICES=$(echo src/service/{iot_config,mobile_config,downlink,follower,gateway,local,packet_router,poc_lora,poc_mobile,router,state_channel,transaction}.proto)
 MESSAGES=$(echo src/{blockchain_txn,entropy,data_rate,region,mapper,price_report}.proto)
 SRC_FILES="$SERVICES $MESSAGES"
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ const SERVICES: &[&str] = &[
     "src/service/poc_entropy.proto",
     "src/service/packet_router.proto",
     "src/service/iot_config.proto",
+    "src/service/mobile_config.proto",
     "src/service/downlink.proto",
     "src/service/packet_verifier.proto",
 ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,15 @@ pub mod services {
         pub use session_key_filter_server::{SessionKeyFilter, SessionKeyFilterServer};
     }
 
+    pub mod mobile_config {
+        include!(concat!(env!("OUT_DIR"), "/helium.mobile_config.rs"));
+        pub use admin_server::{Admin, AdminServer};
+        pub use hotspot_client::HotspotClient;
+        pub use hotspot_server::{Hotspot, HotspotServer};
+        pub use router_client::RouterClient;
+        pub use router_server::{Router, RouterServer};
+    }
+
     pub mod downlink {
         include!(concat!(env!("OUT_DIR"), "/helium.downlink.rs"));
         pub use http_roaming_server::{HttpRoaming, HttpRoamingServer as Server};

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -9,9 +9,10 @@ package helium.mobile_config;
 // == Field Notes ==
 //
 // - Every message including a `signature` field will need to be signed over the
-//   complete message, with the `signature` field set to an empty value.
-//
-// - Every `timestamp` is in milliseconds since unix epoch
+//   complete message, with the `signature` field set to an empty value. Requests
+//   are expected to be signed by the client to validate authorization to make
+//   the request and responses are signed by the mobile_config server to ensure
+//   validity of the data returned
 //
 // - Keypair fields are binary encoded public keys, Rust encoding example here:
 //    https://github.com/helium/helium-crypto-rs/blob/main/src/public_key.rs#L347-L354

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -33,11 +33,13 @@ message hotspot_metadata_req_v1 {
 
 message hotspot_metadata_res_v1 {
   hotspot_metadata metadata = 1;
+  // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   bytes signature = 3;
 }
 
 message hotspot_metadata_stream_req_v1 {
+  // max number of hotspot metadata in each message of the response stream
   uint32 batch_size = 1;
   bytes signature = 2;
 }
@@ -45,6 +47,7 @@ message hotspot_metadata_stream_req_v1 {
 message hotspot_metadata_stream_res_v1 {
   // a list of hotspot metadata numbering up to the request batch size
   repeated hotspot_metadata hotspots = 1;
+  // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   bytes signature = 3;
 }
@@ -59,6 +62,7 @@ message router_get_req_v1 {
 message router_get_res_v1 {
   // Pubkey binary of the requested router, confirming registration
   bytes pubkey = 1;
+  // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   // Signature over the response by the config service
   bytes signature = 3;
@@ -72,6 +76,7 @@ message router_list_req_v1 {
 message router_list_res_v1 {
   // List of public key binaries of all registered routers
   repeated bytes routers = 1;
+  // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   // Signature over the response by the config service
   bytes signature = 3;

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -9,10 +9,10 @@ package helium.mobile_config;
 // == Field Notes ==
 //
 // - Every message including a `signature` field will need to be signed over the
-//   complete message, with the `signature` field set to an empty value. Requests
-//   are expected to be signed by the client to validate authorization to make
-//   the request and responses are signed by the mobile_config server to ensure
-//   validity of the data returned
+//   complete message, with the `signature` field set to an empty value.
+//   Requests are expected to be signed by the client to validate authorization
+//   to make the request and responses are signed by the mobile_config server to
+//   ensure validity of the data returned
 //
 // - Keypair fields are binary encoded public keys, Rust encoding example here:
 //    https://github.com/helium/helium-crypto-rs/blob/main/src/public_key.rs#L347-L354

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package helium.mobile_config;
+
+// ------------------------------------------------------------------
+// Message Definitions
+// ------------------------------------------------------------------
+
+// == Field Notes ==
+//
+// - Every message including a `signature` field will need to be signed over the
+//   complete message, with the `signature` field set to an empty value.
+//
+// - Every `timestamp` is in milliseconds since unix epoch
+//
+// - Keypair fields are binary encoded public keys, Rust encoding example here:
+//    https://github.com/helium/helium-crypto-rs/blob/main/src/public_key.rs#L347-L354
+
+message hotspot_metadata {
+  // The public key binary address and on-chain identity of the hotspot
+  bytes address = 1;
+  // The res12 h3 index asserted address of the hotspot as a string
+  // where an unasserted hotspot returns an empty string
+  string location = 2;
+}
+
+message hotspot_metadata_req_v1 {
+  // The public key address of the hotspot to look up
+  bytes address = 1;
+  bytes signature = 2;
+}
+
+message hotspot_metadata_res_v1 {
+  hotspot_metadata metadata = 1;
+  uint64 timestamp = 2;
+  bytes signature = 3;
+}
+
+message hotspot_metadata_stream_req_v1 {
+  uint32 batch_size = 1;
+  bytes signature = 2;
+}
+
+message hotspot_metadata_stream_res_v1 {
+  // a list of hotspot metadata numbering up to the request batch size
+  repeated hotspot_metadata hotspots = 1;
+  uint64 timestamp = 2;
+  bytes signature = 3;
+}
+
+message router_get_req_v1 {
+  // Pubkey binary of the requested router
+  bytes pubkey = 1;
+  // Signature over the request by the requesting oracle
+  bytes signature = 2;
+}
+
+message router_get_res_v1 {
+  // Pubkey binary of the requested router, confirming registration
+  bytes pubkey = 1;
+  uint64 timestamp = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
+
+message router_list_req_v1 {
+  // Signature over the request by the requesting oracle
+  bytes signature = 1;
+}
+
+message router_list_res_v1 {
+  // List of public key binaries of all registered routers
+  repeated bytes routers = 1;
+  uint64 timestamp = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
+
+message admin_add_key_req_v1 {
+  enum key_type_v1 {
+    // administrative operator key
+    administrator = 0;
+    // packet routing infrastructure key for routing streams
+    packet_router = 1;
+  }
+
+  bytes pubkey = 1;
+  key_type_v1 key_type = 2;
+  // Signature of the request message signed by an admin key
+  // already registered to the config service
+  bytes signature = 3;
+}
+
+message admin_remove_key_req_v1 {
+  bytes pubkey = 1;
+  // Signature of the request message signed by an admin key
+  // already registered to the config service
+  bytes signature = 2;
+}
+
+message admin_key_res_v1 {}
+
+// ------------------------------------------------------------------
+// Service Definitions
+// ------------------------------------------------------------------
+
+service hotspot {
+  // Get metadata info for the specified hotspot
+  rpc metadata(hotspot_metadata_req_v1) returns (hotspot_metadata_res_v1);
+  // Get a stream of hotspot metadata
+  rpc metadata_stream(hotspot_metadata_stream_req_v1)
+      returns (stream hotspot_metadata_stream_res_v1);
+}
+
+service router {
+  // Verify a given router key with data transfer burn authority is registered
+  // returning the requested pubkey binary if present
+  rpc get(router_get_req_v1) returns (router_get_res_v1);
+  // Retrieve a list of all registered router pubkey binaries with burn
+  // authority registered to the config service
+  rpc list(router_list_req_v1) returns (router_list_res_v1);
+}
+
+service admin {
+  // Authorize a public key for validating trusted rpcs
+  rpc add_key(admin_add_key_req_v1) returns (admin_key_res_v1);
+  // Deauthorize a public key for validating trusted rpcs
+  rpc remove_key(admin_remove_key_req_v1) returns (admin_key_res_v1);
+}


### PR DESCRIPTION
define the initial implementation of a `mobile-config` service, the mobile subdao equivalent to the iot-config service that supplies various network configuration and metadata access to the iot subdao data oracles.

the first draft of the mobile config service provides the following three service definitions and their associated message types:
- hotspot service: retrieves individual metadata for a given hotspot, requested by the hotspot's NFT identifying pubkey binary, a successful record retrieval indicates the presence of the request hotspot on-chain. initial hotspot metadata includes the pubkey binary and the hotspot's asserted h3 location index. also includes a "list all" streaming rpc for getting all on-chain hotspots
- router service: confirm the authority of a given router to burn data credits before doing so by verifying the presence of the router's pubkey binary registered with the config service. also includes a "list all" unary rpc for retrieving the public keys of all routers registered to the config service with burn authority to transfer data packets
- admin service: manage registration of authorizing keys to the config service, as well as future management apis to be defined