### PR TITLE
Remove data identity from data transfer session

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -156,13 +156,12 @@ message data_transfer_session_req_v1 {
   uint64 upload_bytes = 2;
   uint64 download_bytes = 3;
   data_transfer_radio_access_technology radio_access_technology = 4;
-  string session_id = 5;
+  string event_id = 5;
   bytes payer = 6;
-  bytes imsi_hash = 7;
 
   // Timestamp in seconds since the epoch
-  uint64 timestamp = 8;
-  bytes signature = 9;
+  uint64 timestamp = 7;
+  bytes signature = 8;
 }
 
 enum data_transfer_radio_access_technology {


### PR DESCRIPTION
In order to keep the end device anonymous, remove identifying information from data session reports