### PR TITLE
Add router_status rpc call

### DIFF
--- a/src/service/local.proto
+++ b/src/service/local.proto
@@ -18,6 +18,12 @@ message keyed_uri {
 message region_req {}
 message region_res { int32 region = 1; }
 
+message router_req {}
+message router_res {
+  string uri = 1;
+  bool connected = 2;
+}
+
 message add_gateway_req {
   bytes owner = 1;
   bytes payer = 2;
@@ -29,5 +35,6 @@ message add_gateway_res { bytes add_gateway_txn = 1; }
 service api {
   rpc pubkey(pubkey_req) returns (pubkey_res);
   rpc region(region_req) returns (region_res);
+  rpc router(router_req) returns (router_res);
   rpc add_gateway(add_gateway_req) returns (add_gateway_res);
 }


### PR DESCRIPTION
Adds a `router` status local GRPC call to get the current connection status of the packet router