### PR TITLE
Add service protos to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/proto",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Helium protobuf definitions compiled to JS with TypeScript types",
   "main": "build/index.js",
   "repository": "git@github.com:helium/proto.git",
@@ -17,7 +17,7 @@
   "scripts": {
     "clean": "rimraf build",
     "setup": "mkdirp build",
-    "compile": "pbjs -w commonjs -t static-module -o build/index.js src/*.proto",
+    "compile": "pbjs -w commonjs -t static-module -o build/index.js src/*.proto src/service/*.proto",
     "types": "pbts -o build/index.d.ts build/index.js",
     "build": "yarn clean && yarn setup && yarn compile && yarn types",
     "test": "jest"


### PR DESCRIPTION
In order to use the service protos to decide the S3 Oracle data, they need to be published for those using npm