### PR TITLE
config services signature/signers and metadata message types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub mod services {
     pub mod mobile_config {
         include!(concat!(env!("OUT_DIR"), "/helium.mobile_config.rs"));
         pub use admin_server::{Admin, AdminServer};
-        pub use hotspot_client::HotspotClient;
-        pub use hotspot_server::{Hotspot, HotspotServer};
+        pub use gateway_client::GatewayClient;
+        pub use gateway_server::{Gateway, GatewayServer};
         pub use router_client::RouterClient;
         pub use router_server::{Router, RouterServer};
     }

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -136,7 +136,15 @@ message route_v1 {
 
 message org_list_req_v1 {}
 
-message org_list_res_v1 { repeated org_v1 orgs = 1; }
+message org_list_res_v1 {
+  repeated org_v1 orgs = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
+}
 
 message org_get_req_v1 { uint64 oui = 1; }
 
@@ -149,6 +157,8 @@ message org_create_helium_req_v1 {
   uint64 timestamp = 4;
   bytes signature = 5;
   repeated bytes delegate_keys = 6;
+  // pubkey binary of the signing keypair
+  bytes signer = 7;
 }
 
 message org_create_roamer_req_v1 {
@@ -159,12 +169,20 @@ message org_create_roamer_req_v1 {
   uint64 timestamp = 4;
   bytes signature = 5;
   repeated bytes delegate_keys = 6;
+  // pubkey binary of the signing keypair
+  bytes signer = 7;
 }
 
 message org_res_v1 {
   org_v1 org = 1;
   uint32 net_id = 2;
   repeated devaddr_constraint_v1 devaddr_constraints = 3;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
+  // Signature over the response by the config service
+  bytes signature = 6;
 }
 
 message org_disable_req_v1 {
@@ -172,33 +190,65 @@ message org_disable_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
-message org_disable_res_v1 { uint64 oui = 1; }
+message org_disable_res_v1 {
+  uint64 oui = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
+}
 
 message org_enable_req_v1 {
   uint64 oui = 1;
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
-message org_enable_res_v1 { uint64 oui = 1; }
+message org_enable_res_v1 {
+  uint64 oui = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
+}
 
 message route_list_req_v1 {
   uint64 oui = 1;
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
-message route_list_res_v1 { repeated route_v1 routes = 1; }
+message route_list_res_v1 {
+  repeated route_v1 routes = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
+}
 
 message route_get_req_v1 {
   string id = 1;
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message route_create_req_v1 {
@@ -207,6 +257,8 @@ message route_create_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
 message route_update_req_v1 {
@@ -214,6 +266,8 @@ message route_update_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message route_delete_req_v1 {
@@ -221,6 +275,18 @@ message route_delete_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
+}
+
+message route_res_v1 {
+  route_v1 route = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
 }
 
 message route_get_euis_req_v1 {
@@ -228,6 +294,8 @@ message route_get_euis_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message route_update_euis_req_v1 {
@@ -236,15 +304,26 @@ message route_update_euis_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
-message route_euis_res_v1 {}
+message route_euis_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
 
 message route_get_devaddr_ranges_req_v1 {
   string route_id = 1;
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message route_update_devaddr_ranges_req_v1 {
@@ -253,14 +332,25 @@ message route_update_devaddr_ranges_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
-message route_devaddr_ranges_res_v1 {}
+message route_devaddr_ranges_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
 
 message route_stream_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 1;
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
 message route_stream_res_v1 {
@@ -270,6 +360,12 @@ message route_stream_res_v1 {
     eui_pair_v1 eui_pair = 3;
     devaddr_range_v1 devaddr_range = 4;
   }
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 5;
+  // pubkey binary of the signing keypair
+  bytes signer = 6;
+  // Signature over the response by the config service
+  bytes signature = 7;
 }
 
 message session_key_filter_v1 {
@@ -284,6 +380,8 @@ message session_key_filter_list_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 2;
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message session_key_filter_get_req_v1 {
@@ -292,6 +390,8 @@ message session_key_filter_get_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
 message session_key_filter_update_req_v1 {
@@ -300,19 +400,36 @@ message session_key_filter_update_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
-message session_key_filter_update_res_v1 {}
+message session_key_filter_update_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
 
 message session_key_filter_stream_req_v1 {
   // in milliseconds since unix epoch
   uint64 timestamp = 1;
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
 message session_key_filter_stream_res_v1 {
   action_v1 action = 1;
   session_key_filter_v1 filter = 2;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
+  // Signature over the response by the config service
+  bytes signature = 5;
 }
 
 message gateway_region_params_req_v1 {
@@ -325,15 +442,30 @@ message gateway_region_params_res_v1 {
   region region = 1;
   blockchain_region_params_v1 params = 2;
   uint64 gain = 3;
+  // Signature over the response by the config service
   bytes signature = 4;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 5;
+  // pubkey binary of the signing keypair
+  bytes signer = 6;
 }
 
 message gateway_location_req_v1 {
   bytes gateway = 1;
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
-message gateway_location_res_v1 { string location = 1; }
+message gateway_location_res_v1 {
+  string location = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  // Signature over the response by the config service
+  bytes signature = 4;
+}
 
 message admin_load_region_req_v1 {
   region region = 1;
@@ -342,9 +474,18 @@ message admin_load_region_req_v1 {
   // indexes
   bytes hex_indexes = 3;
   bytes signature = 4;
+  // pubkey binary of the signing keypair
+  bytes signer = 5;
 }
 
-message admin_load_region_res_v1 {}
+message admin_load_region_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
 
 message admin_add_key_req_v1 {
   enum key_type_v1 {
@@ -352,6 +493,8 @@ message admin_add_key_req_v1 {
     administrator = 0;
     // packet routing infrastructure key for routing streams
     packet_router = 1;
+    // keys for verifying requests from other oracles
+    oracle = 2;
   }
 
   bytes pubkey = 1;
@@ -359,6 +502,8 @@ message admin_add_key_req_v1 {
   // Signature of the request message signed by an admin key
   // already registered to the config service
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message admin_remove_key_req_v1 {
@@ -366,20 +511,35 @@ message admin_remove_key_req_v1 {
   // Signature of the request message signed by an admin key
   // already registered to the config service
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
-message admin_key_res_v1 {}
+message admin_key_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
+
+message gateway_metadata {
+  /// The asserted h3 location of the gateway
+  string location = 1;
+  /// LoRa region derived from the asserted location
+  region region = 2;
+  /// the transmit gain value of the gateway in dbi x 10
+  /// For example 1 dbi = 10, 15 dbi = 150
+  int32 gain = 3;
+  /// The asserted elevation of the gateway
+  int32 elevation = 4;
+}
 
 message gateway_info {
-  /// The asserted h3 location of the gateway.
-  string location = 1;
-  bytes address = 2;
-  bool is_full_hotspot = 3;
-  /// the transmit gain value of the gateway in dbi x 10
-  // For example 1 dbi = 10, 15 dbi = 150
-  int32 gain = 4;
-  region region = 5;
-  int32 elevation = 6;
+  bytes address = 1;
+  bool is_full_hotspot = 2;
+  gateway_metadata metadata = 3;
 }
 
 /// Look up the details of a given hotspot public key
@@ -388,6 +548,8 @@ message gateway_info_req_v1 {
   bytes address = 1;
   /// sig from a key known to the config service
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
 message gateway_info_res_v1 {
@@ -396,6 +558,8 @@ message gateway_info_res_v1 {
   gateway_info info = 2;
   /// sig from the config service
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 /// Request a stream of all active gateways
@@ -403,6 +567,8 @@ message gateway_info_stream_req_v1 {
   uint32 batch_size = 1;
   /// sig from a key known to the config service
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
 /// Active gateway info streaming response containing a batch of gateways
@@ -413,12 +579,16 @@ message gateway_info_stream_res_v1 {
   repeated gateway_info gateways = 2;
   /// sig from the config service
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
 }
 
 message region_params_req_v1 {
   region region = 1;
   /// sig from a key known to the config service
   bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
 }
 
 message region_params_res_v1 {
@@ -426,6 +596,10 @@ message region_params_res_v1 {
   blockchain_region_params_v1 params = 2;
   /// sig from the config service
   bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 5;
 }
 
 // ------------------------------------------------------------------
@@ -453,14 +627,14 @@ service route {
   // List Routes for an Org (auth delegate_keys/owner/admin)
   rpc list(route_list_req_v1) returns (route_list_res_v1);
   // Get Route for an Org (auth delegate_keys/owner/admin)
-  rpc get(route_get_req_v1) returns (route_v1);
+  rpc get(route_get_req_v1) returns (route_res_v1);
   // Create Route for an Org (auth delegate_keys/owner/admin)
-  rpc create(route_create_req_v1) returns (route_v1);
+  rpc create(route_create_req_v1) returns (route_res_v1);
 
   // Update Route for an Org (auth delegate_keys/owner/admin)
-  rpc update(route_update_req_v1) returns (route_v1);
+  rpc update(route_update_req_v1) returns (route_res_v1);
   // Delete Route for an Org (auth delegate_keys/owner/admin)
-  rpc delete (route_delete_req_v1) returns (route_v1);
+  rpc delete (route_delete_req_v1) returns (route_res_v1);
 
   // Get EUIs for a Route (auth delegate_keys/owner/admin)
   rpc get_euis(route_get_euis_req_v1) returns (stream eui_pair_v1);

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -537,8 +537,11 @@ message gateway_metadata {
 }
 
 message gateway_info {
+  // The public key binary address and on-chain identity of the gateway
   bytes address = 1;
+  // Whether or not the hotspot participates in PoC or only transfers data
   bool is_full_hotspot = 2;
+  // The gateway's metadata as recorded on the blockchain
   gateway_metadata metadata = 3;
 }
 

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -17,24 +17,29 @@ package helium.mobile_config;
 // - Keypair fields are binary encoded public keys, Rust encoding example here:
 //    https://github.com/helium/helium-crypto-rs/blob/main/src/public_key.rs#L347-L354
 
-message hotspot_metadata {
-  // The public key binary address and on-chain identity of the hotspot
-  bytes address = 1;
-  // The res12 h3 index asserted address of the hotspot as a string
-  // where an unasserted hotspot returns an empty string
+message gateway_metadata {
+  // The res12 h3 index asserted address of the gateway as a string
+  // where an unasserted gateway returns an empty string
   string location = 2;
 }
 
-message hotspot_metadata_req_v1 {
-  // The public key address of the hotspot to look up
+message gateway_info {
+  // The public key binary address and on-chain identity of the gateway
+  bytes address = 1;
+  // The gateway metadata as recorded on the blockchain
+  gateway_metadata metadata = 2;
+}
+
+message gateway_info_req_v1 {
+  // The public key address of the gateway to look up
   bytes address = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
   bytes signature = 3;
 }
 
-message hotspot_metadata_res_v1 {
-  hotspot_metadata metadata = 1;
+message gateway_info_res_v1 {
+  gateway_info info = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
@@ -42,17 +47,17 @@ message hotspot_metadata_res_v1 {
   bytes signature = 4;
 }
 
-message hotspot_metadata_stream_req_v1 {
-  // max number of hotspot metadata in each message of the response stream
+message gateway_info_stream_req_v1 {
+  // max number of gateway info records in each message of the response stream
   uint32 batch_size = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
   bytes signature = 3;
 }
 
-message hotspot_metadata_stream_res_v1 {
-  // a list of hotspot metadata numbering up to the request batch size
-  repeated hotspot_metadata hotspots = 1;
+message gateway_info_stream_res_v1 {
+  // a list of gateway info numbering up to the request batch size
+  repeated gateway_info gateways = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
@@ -143,12 +148,12 @@ message admin_key_res_v1 {
 // Service Definitions
 // ------------------------------------------------------------------
 
-service hotspot {
-  // Get metadata info for the specified hotspot
-  rpc metadata(hotspot_metadata_req_v1) returns (hotspot_metadata_res_v1);
-  // Get a stream of hotspot metadata
-  rpc metadata_stream(hotspot_metadata_stream_req_v1)
-      returns (stream hotspot_metadata_stream_res_v1);
+service gateway {
+  // Get info for the specified gateway
+  rpc info(gateway_info_req_v1) returns (gateway_info_res_v1);
+  // Get a stream of gateway info
+  rpc info_stream(gateway_info_stream_req_v1)
+      returns (stream gateway_info_stream_res_v1);
 }
 
 service router {

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -88,6 +88,8 @@ message admin_add_key_req_v1 {
     administrator = 0;
     // packet routing infrastructure key for routing streams
     packet_router = 1;
+    // keys for verifying requests from other oracles
+    oracle = 2;
   }
 
   bytes pubkey = 1;

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -28,20 +28,26 @@ message hotspot_metadata {
 message hotspot_metadata_req_v1 {
   // The public key address of the hotspot to look up
   bytes address = 1;
-  bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  bytes signature = 3;
 }
 
 message hotspot_metadata_res_v1 {
   hotspot_metadata metadata = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
-  bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  bytes signature = 4;
 }
 
 message hotspot_metadata_stream_req_v1 {
   // max number of hotspot metadata in each message of the response stream
   uint32 batch_size = 1;
-  bytes signature = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  bytes signature = 3;
 }
 
 message hotspot_metadata_stream_res_v1 {
@@ -49,14 +55,18 @@ message hotspot_metadata_stream_res_v1 {
   repeated hotspot_metadata hotspots = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
-  bytes signature = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  bytes signature = 4;
 }
 
 message router_get_req_v1 {
   // Pubkey binary of the requested router
   bytes pubkey = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
   // Signature over the request by the requesting oracle
-  bytes signature = 2;
+  bytes signature = 3;
 }
 
 message router_get_res_v1 {
@@ -64,13 +74,17 @@ message router_get_res_v1 {
   bytes pubkey = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
   // Signature over the response by the config service
-  bytes signature = 3;
+  bytes signature = 4;
 }
 
 message router_list_req_v1 {
+  // pubkey binary of the signing keypair
+  bytes signer = 1;
   // Signature over the request by the requesting oracle
-  bytes signature = 1;
+  bytes signature = 2;
 }
 
 message router_list_res_v1 {
@@ -78,8 +92,10 @@ message router_list_res_v1 {
   repeated bytes routers = 1;
   // unix epoch timestamp in seconds
   uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
   // Signature over the response by the config service
-  bytes signature = 3;
+  bytes signature = 4;
 }
 
 message admin_add_key_req_v1 {
@@ -94,19 +110,34 @@ message admin_add_key_req_v1 {
 
   bytes pubkey = 1;
   key_type_v1 key_type = 2;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 3;
+  // pubkey binary of the signing keypair
+  bytes signer = 4;
   // Signature of the request message signed by an admin key
   // already registered to the config service
-  bytes signature = 3;
+  bytes signature = 5;
 }
 
 message admin_remove_key_req_v1 {
   bytes pubkey = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
   // Signature of the request message signed by an admin key
   // already registered to the config service
-  bytes signature = 2;
+  bytes signature = 4;
 }
 
-message admin_key_res_v1 {}
+message admin_key_res_v1 {
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  // Signature over the response by the config service
+  bytes signature = 3;
+}
 
 // ------------------------------------------------------------------
 // Service Definitions


### PR DESCRIPTION
allow management of signing keys for oracles to verify requests coming to the config server (from the verifier for instance)