### PR TITLE
Temporarily revert "update proto for non gateway related rewards"

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -167,32 +167,21 @@ message lora_poc_v1 {
   repeated lora_verified_witness_report_v1 unselected_witnesses = 4;
 }
 
-message gateway_reward {
+// iot per-gateway reward share for a given reward period
+// for PoC coverage events provided between the start and end timestamps
+message gateway_reward_share {
   /// Public key of the hotspot
   bytes hotspot_key = 1;
-  /// Amount in iot bones credited to the hotspot for beaconing
+  /// Amount credited to the hotspot for beaconing
   uint64 beacon_amount = 2;
-  /// Amount in iot bones credited to the hotspot for witnessing
+  /// Amount credited to the hotspot for witnessing
   uint64 witness_amount = 3;
-  /// Amount in iot bones credited to the hotspot for data transfer
-  uint64 dc_transfer_amount = 4;
-}
-
-message operational_reward {
-  /// Amount in iot bones credited to the operational fund wallet
-  uint64 amount = 1;
-}
-
-message iot_reward_share {
   /// Unix timestamp in seconds of the start of the reward period
-  uint64 start_period = 1;
+  uint64 start_period = 4;
   /// Unix timestamp in seconds of the end of the reward period
-  uint64 end_period = 2;
-  /// the reward allocations for this share
-  oneof reward {
-    gateway_reward gateway_reward = 3;
-    operational_reward operational_reward = 4;
-  }
+  uint64 end_period = 5;
+  /// Amount credited to the hotspot for data transfer
+  uint64 dc_transfer_amount = 6;
 }
 
 service poc_lora {


### PR DESCRIPTION
Reverts helium/proto#312

Temporarily revert 312 from master to allow Oracles main to compile; Oracles main is not ready to merge https://github.com/helium/oracles/pull/429 and until that is ready to merge the Oracles branch won't compile with the latest proto branch with these changes in place. Since this is a semi-substantial piece of work, temporarily reverting these changes from proto master branch seems the easiest path forward rather than stubbing the fixes into Oracles main