### PR TITLE
add new packet report fields

### DIFF
--- a/src/service/packet_router.proto
+++ b/src/service/packet_router.proto
@@ -6,6 +6,10 @@ import "region.proto";
 import "data_rate.proto";
 
 message packet_router_packet_report_v1 {
+  enum packet_type_v1 {
+    join = 0;
+    uplink = 1;
+  }
   uint64 gateway_timestamp_ms = 1;
   uint64 oui = 2;
   uint32 net_id = 3;
@@ -21,6 +25,9 @@ message packet_router_packet_report_v1 {
   bytes payload_hash = 10;
   uint32 payload_size = 11;
   bool free = 12;
+  packet_type_v1 packet_type = 13;
+  // Timestamp at ingest in millis since unix epoch
+  uint64 received_timestamp = 14;
 }
 
 message packet_router_packet_up_v1 {


### PR DESCRIPTION
Additions to the packet router report proto message. The routing infra has need of the `packet_type_v1` field with the (currently) two possible options while the reward process for routing packets requires a millisecond unix epoch timestamp to allow the verifiers to properly place the routed packet reports within a reward period. The field name and unit for the timestamp mirrors those for the ingest timestamp  of other rewardable accounting reports (notably on the PoC reward side)