### PR TITLE
deprecate old heartbeat invalid reason; add new correct one

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -88,10 +88,12 @@ message heartbeat {
 
 enum heartbeat_validity {
   heartbeat_validity_valid = 0;
-  heartbeat_validity_gateway_owner_not_found = 1;
+  heartbeat_validity_gateway_owner_not_found = 1 [ deprecated = true ];
   heartbeat_validity_heartbeat_outside_range = 2;
   heartbeat_validity_bad_cbsd_id = 3;
   heartbeat_validity_not_operational = 4;
+  /// Gateway not found on the blockchain
+  heartbeat_validity_gateway_not_found = 5;
 }
 
 message speedtest_avg {


### PR DESCRIPTION
Post-solana migration, gateways are no longer linked directly to an owner wallet (for validation purposes) so the existing `GatewayOwnerNotFound` error is no longer a valid option. This change deprecates the old invalid reason and adds a replacement for the situation where the mobile verifier cannot find the heartbeating gateway's pubkey address on the blockchain. (This is a distinct situation from the mobile gateway being _asserted_ to a location which is not something mobile poc cares about at the time of this PR)