### PR TITLE
RPC for updating org records

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -152,9 +152,9 @@ message org_get_req_v1 { uint64 oui = 1; }
 
 message org_create_helium_req_v1 {
   enum helium_net_id {
-    0x00003c = 0;
-    0x60002d = 1;
-    0xc00053 = 2;
+    type0_0x00003c = 0;
+    type3_0x60002d = 1;
+    type6_0xc00053 = 2;
   }
 
   bytes owner = 1;

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -152,9 +152,9 @@ message org_get_req_v1 { uint64 oui = 1; }
 
 message org_create_helium_req_v1 {
   enum helium_net_id {
-    type0_0x00003c = 0;
-    type3_0x60002d = 1;
-    type6_0xc00053 = 2;
+    0x00003c = 0;
+    0x60002d = 1;
+    0xc00053 = 2;
   }
 
   bytes owner = 1;

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -175,6 +175,29 @@ message org_create_roamer_req_v1 {
   bytes signer = 7;
 }
 
+message org_update_req_v1 {
+  message delegate_key_update_v1 {
+    bytes delegate_key = 1;
+    action_v1 action = 2;
+  }
+
+  message devaddr_constraint_update_v1 {
+    devaddr_constraint_v1 constraint = 1;
+    action_v1 action = 2;
+  }
+
+  uint64 oui = 1;
+  oneof update {
+    bytes owner = 2;
+    bytes payer = 3;
+    repeated delegate_key_update_v1 delegate_keys = 4;
+    repeated devaddr_constraint_update_v1 constraints = 5;
+  }
+  uint64 timestamp = 6;
+  bytes signer = 7;
+  bytes signature = 8;
+}
+
 message org_res_v1 {
   org_v1 org = 1;
   uint32 net_id = 2;
@@ -610,6 +633,11 @@ service org {
   rpc create_helium(org_create_helium_req_v1) returns (org_res_v1);
   // Create Org on any network (auth admin only)
   rpc create_roamer(org_create_roamer_req_v1) returns (org_res_v1);
+  // Update any Org (Helium or Roaming)
+  // Modify payer pubkey and add/remove delegate public keys
+  // (delegate_keys/owner/admin) Modify owner pubkey and add/remove devaddr
+  // constraints (auth admin only)
+  rpc update(org_update_req_v1) returns (org_res_v1);
   // Disable an org, this sends a stream route delete update to HPR
   // for all associated routes (auth admin only)
   rpc disable(org_disable_req_v1) returns (org_disable_res_v1);

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -186,16 +186,20 @@ message org_update_req_v1 {
     action_v1 action = 2;
   }
 
-  uint64 oui = 1;
-  oneof update {
-    bytes owner = 2;
-    bytes payer = 3;
-    repeated delegate_key_update_v1 delegate_keys = 4;
-    repeated devaddr_constraint_update_v1 constraints = 5;
+  message update_v1 {
+    oneof update {
+      bytes owner = 1;
+      bytes payer = 2;
+      delegate_key_update_v1 delegate_key = 3;
+      devaddr_constraint_update_v1 constraint = 4;
+    }
   }
-  uint64 timestamp = 6;
-  bytes signer = 7;
-  bytes signature = 8;
+
+  uint64 oui = 1;
+  repeated update_v1 updates = 2;
+  uint64 timestamp = 3;
+  bytes signer = 4;
+  bytes signature = 5;
 }
 
 message org_res_v1 {
@@ -634,9 +638,8 @@ service org {
   // Create Org on any network (auth admin only)
   rpc create_roamer(org_create_roamer_req_v1) returns (org_res_v1);
   // Update any Org (Helium or Roaming)
-  // Modify payer pubkey and add/remove delegate public keys
-  // (delegate_keys/owner/admin) Modify owner pubkey and add/remove devaddr
-  // constraints (auth admin only)
+  // Modify payer and add/remove delegate keys (owner/admin)
+  // Modify owner and add/remove devaddr constraints (auth admin only)
   rpc update(org_update_req_v1) returns (org_res_v1);
   // Disable an org, this sends a stream route delete update to HPR
   // for all associated routes (auth admin only)

--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -151,9 +151,16 @@ message org_list_res_v1 {
 message org_get_req_v1 { uint64 oui = 1; }
 
 message org_create_helium_req_v1 {
+  enum helium_net_id {
+    type0_0x00003c = 0;
+    type3_0x60002d = 1;
+    type6_0xc00053 = 2;
+  }
+
   bytes owner = 1;
   bytes payer = 2;
   // Number of device address needed
+  // Even number required, minimum of 8
   uint64 devaddrs = 3;
   // in milliseconds since unix epoch
   uint64 timestamp = 4;
@@ -161,6 +168,7 @@ message org_create_helium_req_v1 {
   repeated bytes delegate_keys = 6;
   // pubkey binary of the signing keypair
   bytes signer = 7;
+  helium_net_id net_id = 8;
 }
 
 message org_create_roamer_req_v1 {
@@ -191,7 +199,10 @@ message org_update_req_v1 {
       bytes owner = 1;
       bytes payer = 2;
       delegate_key_update_v1 delegate_key = 3;
-      devaddr_constraint_update_v1 constraint = 4;
+      // count of devaddrs to add, in even numbers
+      uint64 devaddrs = 4;
+      // devaddr constraints to explicitly add or remove
+      devaddr_constraint_update_v1 constraint = 5;
     }
   }
 


### PR DESCRIPTION
Allow for updating IoT Org records in the Config Service via RPC.

The single update request message mirrors the `org_res_v1` which includes the full list of pubkeys and devaddr constraints associated to an org record via its OUI, but the `oneof` field allows for supplying a single update at a time for simplifying the API (one request to one change) while still using the separate types within the `oneof` field for the server side to switch off of when authorizing the different types of requests based on the allowed operator (administrator vs. org self-managing)