### PR TITLE
add receiver_nsid to http protocol for 1.1

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -99,6 +99,8 @@ message protocol_http_roaming_v1 {
   string path = 3;
   // Authorization Header
   string auth_header = 4;
+  // Receiver NSID
+  string receiver_nsid = 5;
 }
 
 // Server Route definition


### PR DESCRIPTION
Adds a receiver_nsid field to the http roaming protocol 