### PR TITLE
subscriber id in data transfer requests and events

### DIFF
--- a/src/service/packet_verifier.proto
+++ b/src/service/packet_verifier.proto
@@ -33,4 +33,7 @@ message valid_data_transfer_session {
   // Timestamp in millis of the last ingest file we found a data transfer
   // session in
   uint64 last_timestamp = 7;
+  // below is optional subscriber id which will be populated
+  // if the data transfer req originates from a mobile subscriber
+  bytes subscriber_id = 8;
 }

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -239,6 +239,9 @@ message data_transfer_event {
   // Timestamp in seconds since the epoch
   uint64 timestamp = 7;
   bytes signature = 8;
+  // below is optional subscriber id which will be populated
+  // if the data transfer event originates from a mobile subscriber
+  bytes subscriber_id = 9;
 }
 
 enum data_transfer_radio_access_technology {


### PR DESCRIPTION


Adds support for subscriber id to data pipeline

linked oracle PR: andymck/realtime-mobile-verifier-plus-location-sharing-rewards-tmp1
