### PR TITLE
Add comment confirming that SNR is stored in centibels

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -80,9 +80,9 @@ message lora_witness_report_req_v1 {
   // Timestamp of witness received in nanos since unix epoch
   uint64 timestamp = 4;
   uint32 tmst = 5;
-  // Signal in ddbm
+  // Signal in ddBm
   sint32 signal = 6;
-  // SNR in ddbm
+  // SNR in ddB
   int32 snr = 7;
   // Frequency in Hz
   uint64 frequency = 8;

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -82,6 +82,7 @@ message lora_witness_report_req_v1 {
   uint32 tmst = 5;
   // Signal in ddbm
   sint32 signal = 6;
+  // SNR in ddbm
   int32 snr = 7;
   // Frequency in Hz
   uint64 frequency = 8;


### PR DESCRIPTION
This field lacked a comment, which led me to believe that SNR was being recorded as integer decibels. It is not. It's fixed-point _tenths_ of a decibel, which we have been informally calling "ddB". (Even though, grrr, it's better described as centiBels, or cBm).

To confirm, this is where gateway-rs encodes the SNR into protobuf form:

https://github.com/helium/gateway-rs/blob/f224f15b93fbc140343bc99349ec32e46f1005d4/src/packet.rs#L80C5-L80C46