### PR TITLE
Mapper types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "helium_proto"
 path = "src/lib.rs"
 
 [workspace]
-members = ["beacon"]
+members = ["beacon", "mapper"]
 
 [workspace.dependencies]
 tonic = { version = "0" }

--- a/mapper/Cargo.toml
+++ b/mapper/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mapper_messages"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = { version = "0", features = ["serde"] }
+geo-types = "0"
+hex = "0"
+helium-proto = { path = "../", features = ["services"] }
+h3o = "0"
+lazy_static = "1"
+nmea-parser = "0"
+rust_decimal = "1"
+serde =  {version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+modular-bitfield-msb = "0"
+
+[dev-dependencies]
+rand = "0"

--- a/mapper/src/attach.rs
+++ b/mapper/src/attach.rs
@@ -1,0 +1,195 @@
+use super::*;
+use super::gps::{hdop, latlon, time, altitude, speed};
+
+#[derive(Serialize, Debug, Clone)]
+pub struct MapperAttach {
+    // This allows us to detect censorship efforts. It can roll over.
+    pub attach_counter: u32,
+    pub gps: GpsData,
+    pub candidate: AttachCandidate,
+    // did the attach succeed?
+    pub result: AttachResult,
+}
+
+impl From<MapperAttach> for helium_proto::MapperAttachV1 {
+    fn from(attach_candidate_result: MapperAttach) -> helium_proto::MapperAttachV1 {
+        use helium_proto::mapper_attach_v1::MapperAttachResult as Result;
+
+        helium_proto::MapperAttachV1 {
+            attach_counter: attach_candidate_result.attach_counter,
+            gps: Some(attach_candidate_result.gps.into()),
+            candidate: Some(attach_candidate_result.candidate.into()),
+            result: match attach_candidate_result.result {
+                AttachResult::NoAttach => Result::None,
+                AttachResult::Connected => Result::Connect,
+                AttachResult::LimitedService => Result::LimitedService,
+                AttachResult::NoConnection => Result::NoConnection,
+                AttachResult::Search => Result::Search,
+                AttachResult::NoNetworkService => Result::NoNetworkService,
+            }
+                .into(),
+        }
+    }
+}
+
+impl From<AttachCandidate> for helium_proto::mapper_attach_v1::MapperAttachCandidate {
+    fn from(attach_candidate: AttachCandidate) -> Self {
+        Self {
+            r#type: 0,
+            from_scan_response: attach_candidate.from_scan,
+            delay: attach_candidate.delay,
+            plmn: ((attach_candidate.mcc as u32) << 16) | attach_candidate.mnc as u32,
+            fcn: attach_candidate.earfcn,
+            cid: attach_candidate.cell_id,
+            rsrp: (attach_candidate.rsrp * 100) as i32,
+            rsrq: (attach_candidate.rsrq * 100) as i32,
+        }
+    }
+}
+
+#[derive(BitfieldSpecifier)]
+pub enum CellTech {
+    LTE,
+    NR,
+}
+
+use modular_bitfield_msb::{bitfield, specifiers::*, BitfieldSpecifier};
+
+#[bitfield]
+struct LoraPayload {
+    // we take seconds from 2023-01-01 00:00:00 UTC
+    // 30 bits gives us over 20 years
+    time: B30,
+    // lat ranges from -90 to 90 w/ 5 decimal places (1.11 m accuracy)
+    // shifted to a uint, ranges up to 18000000 => 25 bits
+    lat: B25,
+    // lon ranges from -180 to 180 w/ 5 decimal places (1.11 m accuracy)
+    // shifted to a uint, ranges up to 36000000 => 26 bits
+    lon: B26,
+    // we will not send HDOP values greater than 10m
+    // 0.01m increments => 1000 possible values => 10 bits
+    hdop: B10,
+    // WGS-84 on the surface of earth ranges from +85m (Iceland) to -106m (India)
+    // (https://en.wikipedia.org/wiki/Geoid)
+    // We will represent this in 0.25m steps shifted to a uint by 110m => 0-780 values => 10 bits
+    alt: B10,
+    // Will never exceed 80 km/h. We will represent in 0.25m/h steps => 0-320 values => 9 bits
+    speed: B9,
+    // 0-12 sats => 4 bits
+    num_sats: B4,
+    // TODO check size
+    attach_counter: B32,
+    // TODO check size
+    scan_response: B32,
+    // 1024 seconds should be enough for anyone?
+    delay: B10,
+    // UMTS cell id (28 bits)
+    cid: B36,
+    rsrp: B8,
+    rsrq: B8,
+    cell_type: CellTech,
+    #[bits = 3]
+    #[allow(dead_code)]
+    result: AttachResult,
+    // padding for the struct is necessary to make it byte aligned
+    #[allow(unused)]
+    padding: B6,
+}
+
+pub const RSRP_OFFSET: isize = 150;
+pub const RSRQ_OFFSET: isize = 30;
+
+impl From<MapperAttach> for LoraPayload {
+    fn from(mapper_attach: MapperAttach) -> Self {
+        use latlon::Degrees;
+
+        LoraPayload::new()
+            .with_time(time::to_units(mapper_attach.gps.timestamp))
+            .with_lat(latlon::to_units(Degrees::Lat(mapper_attach.gps.lat)))
+            .with_lon(latlon::to_units(Degrees::Lon(mapper_attach.gps.lon)))
+            .with_hdop(hdop::to_units(mapper_attach.gps.hdop) as u16)
+            .with_alt(altitude::to_units(mapper_attach.gps.altitude) as u16)
+            .with_speed(speed::to_units(mapper_attach.gps.speed) as u16)
+            .with_num_sats(mapper_attach.gps.num_sats)
+            .with_delay(mapper_attach.candidate.delay as u16)
+            .with_attach_counter(mapper_attach.attach_counter)
+            .with_scan_response(mapper_attach.candidate.from_scan)
+            .with_mcc(mapper_attach.candidate.mcc)
+            .with_mnc(mapper_attach.candidate.mnc)
+            .with_cid(mapper_attach.candidate.cell_id)
+            .with_rsrp((mapper_attach.candidate.rsrp + RSRP_OFFSET) as u8)
+            .with_rsrq((mapper_attach.candidate.rsrq + RSRQ_OFFSET) as u8)
+            .with_fcn(mapper_attach.candidate.earfcn)
+        // candidate type default to 0
+    }
+}
+
+impl From<LoraPayload> for MapperAttach {
+    fn from(p: LoraPayload) -> Self {
+        use latlon::Unit;
+        MapperAttach {
+            gps: GpsData {
+                timestamp: time::from_units(p.time()),
+                lat: latlon::from_units(Unit::Lat(p.lat())),
+                lon: latlon::from_units(Unit::Lon(p.lon())),
+                hdop: hdop::from_units(p.hdop().into()),
+                altitude: altitude::from_units(p.alt().into()),
+                num_sats: p.num_sats(),
+                speed: speed::from_units(p.speed().into()),
+            },
+            attach_counter: p.attach_counter(),
+            candidate: AttachCandidate {
+                delay: p.delay() as u32,
+                from_scan: p.scan_response(),
+                rsrp: (p.rsrp() as isize) - RSRP_OFFSET,
+                rsrq: (p.rsrq() as isize) - RSRQ_OFFSET,
+                cell_type: p.cell_type.into(),
+            },
+
+            result: p.result.into(),
+        }
+
+    }
+}
+
+impl MapperAttach {
+    pub fn to_proto_serialization(&self) -> std::result::Result<Vec<u8>, helium_proto::EncodeError> {
+        use helium_proto::Message;
+        let proto = helium_proto::MapperAttachV1::from(self.clone());
+        let mut buffer = vec![];
+        proto.encode(&mut buffer)?;
+        Ok(buffer)
+    }
+}
+
+#[derive(Serialize, Debug, Clone, BitfieldSpecifier)]
+#[bits = 3]
+pub enum AttachResult {
+    NoAttach,
+    Connected,
+    LimitedService,
+    NoConnection,
+    Search,
+    NoNetworkService,
+}
+
+impl AttachResult {
+    pub fn is_successful(&self) -> bool {
+        !matches!(self, AttachResult::NoAttach)
+    }
+}
+
+impl std::str::FromStr for AttachResult {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(AttachResult::NoAttach),
+            "CONNECT" => Ok(AttachResult::Connected),
+            "LIMSERV" => Ok(AttachResult::LimitedService),
+            "NOCONN" => Ok(AttachResult::NoConnection),
+            "SEARCH" => Ok(AttachResult::Search),
+            _ => Err(Error::UnexpectedAttachResultStr(s.into())),
+        }
+    }
+}

--- a/mapper/src/gps.rs
+++ b/mapper/src/gps.rs
@@ -1,7 +1,4 @@
 use super::*;
-
-use chrono::{prelude::*, DateTime, NaiveDateTime};
-
 use rust_decimal::Decimal;
 
 pub const ZERO_DECIMAL: Decimal = Decimal::from_parts(0, 0, 0, false, 0);
@@ -27,16 +24,6 @@ pub struct GpsData {
 use nmea_parser::gnss::{GgaData, VtgData};
 
 impl GpsData {
-    pub fn is_parseable(gga: &GgaData, vtg: &VtgData) -> bool {
-        gga.timestamp.is_some()
-            && gga.latitude.is_some()
-            && gga.longitude.is_some()
-            && gga.hdop.is_some()
-            && gga.geoid_separation.is_some()
-            && gga.satellite_count.is_some()
-            && vtg.sog_kph.is_some()
-    }
-
     pub fn is_locked(&self) -> bool {
         self.num_sats >= 3 && self.hdop > ZERO_DECIMAL
     }
@@ -49,81 +36,64 @@ impl GpsData {
         Ok(coord.to_cell(Resolution::Fifteen))
     }
 
-    pub fn new(gga: &GgaData, vtg: &VtgData, date: &str) -> Result<Option<GpsData>> {
-        let day = date[..2].parse::<u32>()?;
-        let month = date[2..4].parse::<u32>()?;
-        let year = date[4..].parse::<i32>()? + 2000;
-        Ok(
-            if let (
-                Some(timestamp),
-                Some(latitude),
-                Some(longitude),
-                Some(hdop),
-                Some(altitude),
-                Some(num_sats),
-                Some(speed),
-            ) = (
-                gga.timestamp,
-                gga.latitude,
-                gga.longitude,
-                gga.hdop,
-                gga.altitude,
-                gga.satellite_count,
-                vtg.sog_kph,
-            ) {
-                Some(GpsData {
-                    timestamp: Utc
-                        .with_ymd_and_hms(
-                            year,
-                            month,
-                            day,
-                            timestamp.hour(),
-                            timestamp.minute(),
-                            timestamp.second(),
-                        )
-                        .unwrap(),
-                    lat: Decimal::new((latitude * 1000000.0) as i64, 6),
-                    lon: Decimal::new((longitude * 1000000.0) as i64, 6),
-                    hdop: Decimal::new((hdop * 100.0) as i64, 2),
-                    altitude: Decimal::new((altitude * 100.0) as i64, 2),
-                    num_sats,
-                    speed: Decimal::new((speed * 100.0) as i64, 2),
-                })
-            } else {
-                None
-            },
-        )
+    #[cfg(test)]
+    pub fn random() -> Self {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let timestamp = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+        let value = GpsData {
+            timestamp,
+            lat: Decimal::new(rng.gen_range(-90_00000..90_00000), 5),
+            lon: Decimal::new(rng.gen_range(-180_00000..180_00000), 5),
+            hdop: Decimal::new(rng.gen_range(0..10_00), 2),
+            //// WGS-84 on the surface of earth ranges from +85m (Iceland) to -106m (India)
+            altitude: Decimal::new(rng.gen_range(-106_00..85_00), 2),
+            num_sats: rng.gen_range(0..12),
+            speed: Decimal::new(rng.gen_range(0..50_00), 2),
+        };
+        value
+    }
+
+    #[cfg(test)]
+    /// provides a rounded GPS value for easy roundtrip testing to lorawan payloads
+    pub fn rounded() -> Self {
+        let timestamp = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+        GpsData {
+            timestamp,
+            lat: Decimal::new(-50_12345, 5),
+            lon: Decimal::new(120_12345, 5),
+            hdop: Decimal::new(9_05, 2),
+            altitude: Decimal::new(9_25, 2),
+            num_sats: 5,
+            speed: Decimal::new(50_50, 2),
+        }
     }
 }
 
 impl From<GpsData> for helium_proto::MapperGpsV1 {
     fn from(gps_data: GpsData) -> helium_proto::MapperGpsV1 {
-        use latlon::{Degrees};
-
         helium_proto::MapperGpsV1 {
-            timestamp: time::to_units(gps_data.timestamp),
-            lat: latlon::to_units(Degrees::Lat(gps_data.lat)),
-            lon: latlon::to_units(Degrees::Lon(gps_data.lon)),
+            timestamp: time::to_proto_units(gps_data.timestamp),
+            lat: latlon::to_proto_units(gps_data.lat),
+            lon: latlon::to_proto_units(gps_data.lon),
             hdop: hdop::to_units(gps_data.hdop),
-            altitude: altitude::to_units(gps_data.altitude),
+            altitude: altitude::to_proto_units(gps_data.altitude),
             num_sats: gps_data.num_sats as u32,
-            speed: speed::to_units(gps_data.speed),
+            speed: speed::to_proto_units(gps_data.speed),
         }
     }
 }
 
 impl From<helium_proto::MapperGpsV1> for GpsData {
     fn from(gps_proto: helium_proto::MapperGpsV1) -> GpsData {
-        use latlon::Unit;
-
         GpsData {
-            timestamp: time::from_units(gps_proto.timestamp),
-            lat: latlon::from_units(Unit::Lat(gps_proto.lat)),
-            lon: latlon::from_units(Unit::Lon(gps_proto.lon)),
+            timestamp: time::from_proto_units(gps_proto.timestamp),
+            lat: latlon::from_proto_units(gps_proto.lat),
+            lon: latlon::from_proto_units(gps_proto.lon),
             hdop: hdop::from_units(gps_proto.hdop),
-            altitude: altitude::from_units(gps_proto.altitude),
+            altitude: altitude::from_proto_units(gps_proto.altitude),
             num_sats: gps_proto.num_sats as u8,
-            speed: speed::from_units(gps_proto.speed),
+            speed: speed::from_proto_units(gps_proto.speed),
         }
     }
 }
@@ -147,13 +117,24 @@ pub(crate) mod time {
     // time for 2023-01-01 00:00:00 UTC
     const REFERENCE: i64 = 1672531200;
 
-    pub fn to_units(datetime: DateTime<Utc>) -> u32 {
+    pub fn to_lora_units(datetime: DateTime<Utc>) -> u32 {
         (datetime.timestamp() - REFERENCE) as u32
     }
 
-    pub fn from_units(timestamp: u32) -> DateTime<Utc> {
+    pub fn from_lora_units(timestamp: u32) -> DateTime<Utc> {
         DateTime::<Utc>::from_utc(
             NaiveDateTime::from_timestamp_opt(timestamp as i64 + REFERENCE, 0).unwrap(),
+            Utc,
+        )
+    }
+
+    pub fn to_proto_units(datetime: DateTime<Utc>) -> u64 {
+        datetime.timestamp() as u64
+    }
+
+    pub fn from_proto_units(timestamp: u64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp_opt(timestamp as i64, 0).unwrap(),
             Utc,
         )
     }
@@ -164,15 +145,27 @@ pub(crate) mod time {
         use chrono::TimeZone;
 
         #[test]
-        fn time_to_units() {
+        fn time_to_lora_units() {
             let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
-            assert_eq!(to_units(datetime), 5);
+            assert_eq!(to_lora_units(datetime), 5);
         }
 
         #[test]
-        fn time_from_units() {
+        fn time_from_lora_units() {
             let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
-            assert_eq!(from_units(5), datetime);
+            assert_eq!(from_lora_units(5), datetime);
+        }
+
+        #[test]
+        fn time_to_proto_units() {
+            let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+            assert_eq!(to_proto_units(datetime), 1672531205);
+        }
+
+        #[test]
+        fn time_from_proto_units() {
+            let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+            assert_eq!(from_proto_units(1672531205), datetime);
         }
     }
 }
@@ -193,7 +186,7 @@ pub(crate) mod latlon {
         Lon(u32),
     }
 
-    pub(crate) fn to_units(coordinate: Degrees) -> u32 {
+    pub(crate) fn to_lora_units(coordinate: Degrees) -> u32 {
         let offset_degrees = match coordinate {
             Degrees::Lat(lat) => lat + LAT_OFFSET,
             Degrees::Lon(lon) => lon + LON_OFFSET,
@@ -203,13 +196,23 @@ pub(crate) mod latlon {
         scaled.to_string().parse::<u32>().unwrap()
     }
 
-    pub(crate) fn from_units(unit: Unit) -> Decimal {
+    pub(crate) fn from_lora_units(unit: Unit) -> Decimal {
         match unit {
             // (-90, 90)
             Unit::Lat(lat) => Decimal::new(lat.into(), 5) - LAT_OFFSET,
             // (-180, 180)
             Unit::Lon(lon) => Decimal::new(lon.into(), 5) - LON_OFFSET,
         }
+    }
+
+    pub(crate) fn to_proto_units(coordinate: Decimal) -> i32 {
+        let multiplier = Decimal::new(100000, 0);
+        let scaled = coordinate.checked_mul(multiplier).unwrap().round();
+        scaled.to_string().parse::<i32>().unwrap()
+    }
+
+    pub(crate) fn from_proto_units(unit: i32) -> Decimal {
+        Decimal::new(unit.into(), 5)
     }
 
     #[cfg(test)]
@@ -228,23 +231,33 @@ pub(crate) mod latlon {
         }
 
         #[test]
-        fn roundtrip_lat() {
+        fn roundtrip_lat_lora() {
             let mut rng = rand::thread_rng();
             let random_lat = rng.gen_range(-90_00000..90_00000);
             let lat = Decimal::new(random_lat, 5);
-            let units = to_units(Degrees::Lat(lat));
-            let degrees = from_units(Unit::Lat(units));
+            let units = to_lora_units(Degrees::Lat(lat));
+            let degrees = from_lora_units(Unit::Lat(units));
             assert_eq!(lat, degrees);
         }
 
         #[test]
-        fn roundtrip_lon() {
+        fn roundtrip_lon_lora() {
             let mut rng = rand::thread_rng();
             let random_lon = rng.gen_range(-180_00000..180_00000);
             let lon = Decimal::new(random_lon, 5);
-            let units = to_units(Degrees::Lon(lon));
-            let degrees = from_units(Unit::Lon(units));
+            let units = to_lora_units(Degrees::Lon(lon));
+            let degrees = from_lora_units(Unit::Lon(units));
             assert_eq!(lon, degrees);
+        }
+
+        #[test]
+        fn roundtrip_latlon_proto() {
+            let mut rng = rand::thread_rng();
+            let random_lat = rng.gen_range(-90_00000..90_00000);
+            let lat = Decimal::new(random_lat, 5);
+            let units = to_proto_units(lat);
+            let degrees = from_proto_units(units);
+            assert_eq!(lat, degrees);
         }
     }
 }
@@ -254,21 +267,35 @@ pub(crate) mod altitude {
     #[allow(clippy::inconsistent_digit_grouping)]
     const ALTITUDE_OFFSET: Decimal = Decimal::from_parts(110_00, 0, 0, false, 2);
     #[allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
-    const ALTITUDE_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+    const ALTITUDE_LORA_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+    #[allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
+    const ALTITUDE_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 2);
 
-    pub fn to_units(altitude: Decimal) -> u32 {
+    pub fn to_lora_units(altitude: Decimal) -> u32 {
         let offset_altitude = altitude + ALTITUDE_OFFSET;
         let scaled = offset_altitude
-            .checked_div(ALTITUDE_SCALAR)
+            .checked_div(ALTITUDE_LORA_SCALAR)
             .unwrap()
             .round();
         scaled.to_string().parse::<u32>().unwrap()
     }
 
-    pub fn from_units(altitude: u32) -> Decimal {
+    pub fn from_lora_units(altitude: u32) -> Decimal {
         let altitude_unscaled = Decimal::new(altitude.into(), 0);
-        let altitude_unoffset = altitude_unscaled.checked_mul(ALTITUDE_SCALAR).unwrap();
+        let altitude_unoffset = altitude_unscaled.checked_mul(ALTITUDE_LORA_SCALAR).unwrap();
         altitude_unoffset - ALTITUDE_OFFSET
+    }
+
+    pub fn to_proto_units(altitude: Decimal) -> i32 {
+        let scaled = altitude.checked_div(ALTITUDE_PROTO_SCALAR).unwrap().round();
+        scaled.to_string().parse::<i32>().unwrap()
+    }
+
+    pub fn from_proto_units(altitude: i32) -> Decimal {
+        let altitude_unscaled = Decimal::new(altitude.into(), 0);
+        altitude_unscaled
+            .checked_mul(ALTITUDE_PROTO_SCALAR)
+            .unwrap()
     }
 
     #[cfg(test)]
@@ -280,38 +307,38 @@ pub(crate) mod altitude {
         }
 
         #[test]
-        fn altitude_lower_limit_roundtrip() {
+        fn altitude_lower_limit_roundtrip_lora() {
             let altitude = Decimal::new(-110_00, 2);
             assert_eq!(altitude.to_string(), "-110.00");
-            let units = to_units(altitude);
+            let units = to_lora_units(altitude);
             assert_eq!(0, units);
-            let altitude = from_units(units);
+            let altitude = from_lora_units(units);
             assert_eq!(altitude.to_string(), "-110.00");
         }
 
         #[test]
-        fn altitude_zero_roundtrip() {
+        fn altitude_zero_roundtrip_lora() {
             let altitude = Decimal::new(0, 2);
             assert_eq!(altitude.to_string(), "0.00");
-            let units = to_units(altitude);
+            let units = to_lora_units(altitude);
             assert_eq!(110_00 / 25, units);
-            let altitude = from_units(units);
+            let altitude = from_lora_units(units);
             assert_eq!(altitude.to_string(), "0.00");
         }
 
         #[test]
-        fn altitude_round_down() {
+        fn altitude_round_down_lora() {
             let altitude = Decimal::new(10_12, 2);
             assert_eq!(altitude.to_string(), "10.12");
-            let altitude = from_units(to_units(altitude));
+            let altitude = from_lora_units(to_lora_units(altitude));
             assert_eq!(altitude.to_string(), "10.00");
         }
 
         #[test]
-        fn altitude_round_up() {
+        fn altitude_round_up_lora() {
             let altitude = Decimal::new(10_21, 2);
             assert_eq!(altitude.to_string(), "10.21");
-            let altitude = from_units(to_units(altitude));
+            let altitude = from_lora_units(to_lora_units(altitude));
             assert_eq!(altitude.to_string(), "10.25");
         }
     }
@@ -320,16 +347,27 @@ pub(crate) mod altitude {
 pub(crate) mod speed {
     use super::*;
     #[allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
-    const SPEED_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+    const SPEED_LORA_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+    const SPEED_PROTO_SCALAR: Decimal = Decimal::from_parts(1, 0, 0, false, 2);
 
-    pub fn to_units(speed: Decimal) -> u32 {
-        let scaled = speed.checked_div(SPEED_SCALAR).unwrap().round();
+    pub fn to_lora_units(speed: Decimal) -> u32 {
+        let scaled = speed.checked_div(SPEED_LORA_SCALAR).unwrap().round();
         scaled.to_string().parse::<u32>().unwrap()
     }
 
-    pub fn from_units(speed: u32) -> Decimal {
+    pub fn from_lora_units(speed: u32) -> Decimal {
         let speed_unscaled = Decimal::new(speed.into(), 0);
-        speed_unscaled.checked_mul(SPEED_SCALAR).unwrap()
+        speed_unscaled.checked_mul(SPEED_LORA_SCALAR).unwrap()
+    }
+
+    pub fn to_proto_units(speed: Decimal) -> u32 {
+        let scaled = speed.checked_div(SPEED_PROTO_SCALAR).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub fn from_proto_units(speed: u32) -> Decimal {
+        let speed_unscaled = Decimal::new(speed.into(), 0);
+        speed_unscaled.checked_mul(SPEED_PROTO_SCALAR).unwrap()
     }
 
     #[cfg(test)]
@@ -337,75 +375,47 @@ pub(crate) mod speed {
         use super::*;
 
         #[test]
-        fn speed_upper_limit_roundtrip() {
+        fn speed_upper_limit_roundtrip_lora() {
             let speed = Decimal::new(80_00, 2);
             assert_eq!(speed.to_string(), "80.00");
-            let units = to_units(speed);
+            let units = to_lora_units(speed);
             assert_eq!(80_00 / 25, units);
-            let speed = from_units(units);
+            let speed = from_lora_units(units);
             assert_eq!(speed.to_string(), "80.00");
         }
 
         #[test]
-        fn speed_round_down() {
+        fn speed_round_down_lora() {
             let altitude = Decimal::new(20_12, 2);
             assert_eq!(altitude.to_string(), "20.12");
-            let altitude = from_units(to_units(altitude));
+            let altitude = from_lora_units(to_lora_units(altitude));
             assert_eq!(altitude.to_string(), "20.00");
         }
 
         #[test]
-        fn speed_round_up() {
+        fn speed_round_up_lora() {
             let altitude = Decimal::new(20_13, 2);
             assert_eq!(altitude.to_string(), "20.13");
-            let altitude = from_units(to_units(altitude));
+            let altitude = from_lora_units(to_lora_units(altitude));
             assert_eq!(altitude.to_string(), "20.25");
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
+    use helium_proto::Message;
 
     #[test]
-    fn test_latlon_from_degrees() {
-        // -122.281358
-        let degrees = Decimal::new(-122281358, 6);
-        let latlon_units = latlon_units_from_degrees(degrees);
-        // -12228136
-        assert_eq!(latlon_units, -12228136);
-    }
-
-    #[test]
-    fn hdop_roundtrip() {
-        let hdop = Decimal::new(123, 2);
-        assert_eq!(hdop.to_string(), "1.23"); // 1.23 m
-        let hdop_units = units_from_hdop(hdop);
-        assert_eq!(hdop_units, 123);
-        let hdop_roundtrip = hdop_from_units(hdop_units);
-        assert_eq!(hdop_roundtrip, hdop);
-    }
-
-    #[test]
-    /// The roundtrip is expected to round to the closes 0.25m
-    fn altitude_roundtrip() {
-        let altitude = Decimal::new(-4979, 2);
-        assert_eq!(altitude.to_string(), "-49.79"); // -49.79 m
-        let altitude_units = units_from_altitude(altitude);
-        assert_eq!(altitude_units, -4979 / 25);
-        let altitude_roundtrip = altitude_from_units(altitude_units);
-        assert_eq!(altitude_roundtrip.to_string(), "-49.75");
-    }
-
-    #[test]
-    /// The roundtrip is expected to round to the closes 0.25 km
-    fn speed_roundtrip() {
-        let speed = Decimal::new(5524, 2);
-        assert_eq!(speed.to_string(), "55.24"); // 55.24 km/h
-        let speed_units = units_from_speed(speed);
-        assert_eq!(speed_units, 5524 / 25 + 1);
-        let speed_roundtrip = speed_from_units(speed_units);
-        assert_eq!(speed_roundtrip.to_string(), "55.25");
+    fn gps_roundtrip_proto() {
+        let gps = GpsData::rounded();
+        let proto: helium_proto::MapperGpsV1 = gps.clone().into();
+        let mut proto_bytes = Vec::new();
+        proto.encode(&mut proto_bytes).unwrap();
+        let gps_returned = helium_proto::MapperGpsV1::decode(proto_bytes.as_slice())
+            .unwrap()
+            .into();
+        assert_eq!(gps, gps_returned);
     }
 }

--- a/mapper/src/gps.rs
+++ b/mapper/src/gps.rs
@@ -1,0 +1,411 @@
+use super::*;
+
+use chrono::{prelude::*, DateTime, NaiveDateTime};
+
+use rust_decimal::Decimal;
+
+pub const ZERO_DECIMAL: Decimal = Decimal::from_parts(0, 0, 0, false, 0);
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct GpsData {
+    /// UTC of position fix
+    pub timestamp: DateTime<Utc>,
+    /// Latitude in degrees
+    pub lat: Decimal,
+    /// Longitude in degrees
+    pub lon: Decimal,
+    /// Horizontal dilution of position
+    pub hdop: Decimal,
+    /// Height of geoid (mean sea level) above WGS84 ellipsoid
+    pub altitude: Decimal,
+    /// Number of satellites in use
+    pub num_sats: u8,
+    /// Speed over ground (SoG), km/h
+    pub speed: Decimal,
+}
+
+use nmea_parser::gnss::{GgaData, VtgData};
+
+impl GpsData {
+    pub fn is_parseable(gga: &GgaData, vtg: &VtgData) -> bool {
+        gga.timestamp.is_some()
+            && gga.latitude.is_some()
+            && gga.longitude.is_some()
+            && gga.hdop.is_some()
+            && gga.geoid_separation.is_some()
+            && gga.satellite_count.is_some()
+            && vtg.sog_kph.is_some()
+    }
+
+    pub fn is_locked(&self) -> bool {
+        self.num_sats >= 3 && self.hdop > ZERO_DECIMAL
+    }
+
+    pub fn to_h3_cell(&self) -> Result<h3o::CellIndex> {
+        use h3o::{LatLng, Resolution};
+
+        use rust_decimal::prelude::ToPrimitive;
+        let coord = LatLng::new(self.lat.to_f64().unwrap(), self.lat.to_f64().unwrap())?;
+        Ok(coord.to_cell(Resolution::Fifteen))
+    }
+
+    pub fn new(gga: &GgaData, vtg: &VtgData, date: &str) -> Result<Option<GpsData>> {
+        let day = date[..2].parse::<u32>()?;
+        let month = date[2..4].parse::<u32>()?;
+        let year = date[4..].parse::<i32>()? + 2000;
+        Ok(
+            if let (
+                Some(timestamp),
+                Some(latitude),
+                Some(longitude),
+                Some(hdop),
+                Some(altitude),
+                Some(num_sats),
+                Some(speed),
+            ) = (
+                gga.timestamp,
+                gga.latitude,
+                gga.longitude,
+                gga.hdop,
+                gga.altitude,
+                gga.satellite_count,
+                vtg.sog_kph,
+            ) {
+                Some(GpsData {
+                    timestamp: Utc
+                        .with_ymd_and_hms(
+                            year,
+                            month,
+                            day,
+                            timestamp.hour(),
+                            timestamp.minute(),
+                            timestamp.second(),
+                        )
+                        .unwrap(),
+                    lat: Decimal::new((latitude * 1000000.0) as i64, 6),
+                    lon: Decimal::new((longitude * 1000000.0) as i64, 6),
+                    hdop: Decimal::new((hdop * 100.0) as i64, 2),
+                    altitude: Decimal::new((altitude * 100.0) as i64, 2),
+                    num_sats,
+                    speed: Decimal::new((speed * 100.0) as i64, 2),
+                })
+            } else {
+                None
+            },
+        )
+    }
+}
+
+impl From<GpsData> for helium_proto::MapperGpsV1 {
+    fn from(gps_data: GpsData) -> helium_proto::MapperGpsV1 {
+        use latlon::{Degrees};
+
+        helium_proto::MapperGpsV1 {
+            timestamp: time::to_units(gps_data.timestamp),
+            lat: latlon::to_units(Degrees::Lat(gps_data.lat)),
+            lon: latlon::to_units(Degrees::Lon(gps_data.lon)),
+            hdop: hdop::to_units(gps_data.hdop),
+            altitude: altitude::to_units(gps_data.altitude),
+            num_sats: gps_data.num_sats as u32,
+            speed: speed::to_units(gps_data.speed),
+        }
+    }
+}
+
+impl From<helium_proto::MapperGpsV1> for GpsData {
+    fn from(gps_proto: helium_proto::MapperGpsV1) -> GpsData {
+        use latlon::Unit;
+
+        GpsData {
+            timestamp: time::from_units(gps_proto.timestamp),
+            lat: latlon::from_units(Unit::Lat(gps_proto.lat)),
+            lon: latlon::from_units(Unit::Lon(gps_proto.lon)),
+            hdop: hdop::from_units(gps_proto.hdop),
+            altitude: altitude::from_units(gps_proto.altitude),
+            num_sats: gps_proto.num_sats as u8,
+            speed: speed::from_units(gps_proto.speed),
+        }
+    }
+}
+
+pub(crate) mod hdop {
+    use super::*;
+
+    pub fn to_units(hdop: Decimal) -> u32 {
+        let multiplier = Decimal::new(100, 0);
+        let scaled = hdop.checked_mul(multiplier).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub(crate) fn from_units(hdop: u32) -> Decimal {
+        Decimal::new(hdop.into(), 2)
+    }
+}
+
+pub(crate) mod time {
+    use super::*;
+    // time for 2023-01-01 00:00:00 UTC
+    const REFERENCE: i64 = 1672531200;
+
+    pub fn to_units(datetime: DateTime<Utc>) -> u32 {
+        (datetime.timestamp() - REFERENCE) as u32
+    }
+
+    pub fn from_units(timestamp: u32) -> DateTime<Utc> {
+        DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp_opt(timestamp as i64 + REFERENCE, 0).unwrap(),
+            Utc,
+        )
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+        use chrono::TimeZone;
+
+        #[test]
+        fn time_to_units() {
+            let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+            assert_eq!(to_units(datetime), 5);
+        }
+
+        #[test]
+        fn time_from_units() {
+            let datetime = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+            assert_eq!(from_units(5), datetime);
+        }
+    }
+}
+
+pub(crate) mod latlon {
+    use super::*;
+
+    const LAT_OFFSET: Decimal = Decimal::from_parts(9000000, 0, 0, false, 5);
+    const LON_OFFSET: Decimal = Decimal::from_parts(18000000, 0, 0, false, 5);
+
+    pub(crate) enum Degrees {
+        Lat(Decimal),
+        Lon(Decimal),
+    }
+
+    pub(crate) enum Unit {
+        Lat(u32),
+        Lon(u32),
+    }
+
+    pub(crate) fn to_units(coordinate: Degrees) -> u32 {
+        let offset_degrees = match coordinate {
+            Degrees::Lat(lat) => lat + LAT_OFFSET,
+            Degrees::Lon(lon) => lon + LON_OFFSET,
+        };
+        let multiplier = Decimal::new(100000, 0);
+        let scaled = offset_degrees.checked_mul(multiplier).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub(crate) fn from_units(unit: Unit) -> Decimal {
+        match unit {
+            // (-90, 90)
+            Unit::Lat(lat) => Decimal::new(lat.into(), 5) - LAT_OFFSET,
+            // (-180, 180)
+            Unit::Lon(lon) => Decimal::new(lon.into(), 5) - LON_OFFSET,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use rand::Rng;
+
+        #[test]
+        fn lat_constant() {
+            assert_eq!(LAT_OFFSET.to_string(), "90.00000");
+        }
+
+        #[test]
+        fn lon_constant() {
+            assert_eq!(LON_OFFSET.to_string(), "180.00000");
+        }
+
+        #[test]
+        fn roundtrip_lat() {
+            let mut rng = rand::thread_rng();
+            let random_lat = rng.gen_range(-90_00000..90_00000);
+            let lat = Decimal::new(random_lat, 5);
+            let units = to_units(Degrees::Lat(lat));
+            let degrees = from_units(Unit::Lat(units));
+            assert_eq!(lat, degrees);
+        }
+
+        #[test]
+        fn roundtrip_lon() {
+            let mut rng = rand::thread_rng();
+            let random_lon = rng.gen_range(-180_00000..180_00000);
+            let lon = Decimal::new(random_lon, 5);
+            let units = to_units(Degrees::Lon(lon));
+            let degrees = from_units(Unit::Lon(units));
+            assert_eq!(lon, degrees);
+        }
+    }
+}
+
+pub(crate) mod altitude {
+    use super::*;
+    #[allow(clippy::inconsistent_digit_grouping)]
+    const ALTITUDE_OFFSET: Decimal = Decimal::from_parts(110_00, 0, 0, false, 2);
+    #[allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
+    const ALTITUDE_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+
+    pub fn to_units(altitude: Decimal) -> u32 {
+        let offset_altitude = altitude + ALTITUDE_OFFSET;
+        let scaled = offset_altitude
+            .checked_div(ALTITUDE_SCALAR)
+            .unwrap()
+            .round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub fn from_units(altitude: u32) -> Decimal {
+        let altitude_unscaled = Decimal::new(altitude.into(), 0);
+        let altitude_unoffset = altitude_unscaled.checked_mul(ALTITUDE_SCALAR).unwrap();
+        altitude_unoffset - ALTITUDE_OFFSET
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+        #[test]
+        fn altitude_offset() {
+            assert_eq!(ALTITUDE_OFFSET.to_string(), "110.00");
+        }
+
+        #[test]
+        fn altitude_lower_limit_roundtrip() {
+            let altitude = Decimal::new(-110_00, 2);
+            assert_eq!(altitude.to_string(), "-110.00");
+            let units = to_units(altitude);
+            assert_eq!(0, units);
+            let altitude = from_units(units);
+            assert_eq!(altitude.to_string(), "-110.00");
+        }
+
+        #[test]
+        fn altitude_zero_roundtrip() {
+            let altitude = Decimal::new(0, 2);
+            assert_eq!(altitude.to_string(), "0.00");
+            let units = to_units(altitude);
+            assert_eq!(110_00 / 25, units);
+            let altitude = from_units(units);
+            assert_eq!(altitude.to_string(), "0.00");
+        }
+
+        #[test]
+        fn altitude_round_down() {
+            let altitude = Decimal::new(10_12, 2);
+            assert_eq!(altitude.to_string(), "10.12");
+            let altitude = from_units(to_units(altitude));
+            assert_eq!(altitude.to_string(), "10.00");
+        }
+
+        #[test]
+        fn altitude_round_up() {
+            let altitude = Decimal::new(10_21, 2);
+            assert_eq!(altitude.to_string(), "10.21");
+            let altitude = from_units(to_units(altitude));
+            assert_eq!(altitude.to_string(), "10.25");
+        }
+    }
+}
+
+pub(crate) mod speed {
+    use super::*;
+    #[allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
+    const SPEED_SCALAR: Decimal = Decimal::from_parts(0_25, 0, 0, false, 2);
+
+    pub fn to_units(speed: Decimal) -> u32 {
+        let scaled = speed.checked_div(SPEED_SCALAR).unwrap().round();
+        scaled.to_string().parse::<u32>().unwrap()
+    }
+
+    pub fn from_units(speed: u32) -> Decimal {
+        let speed_unscaled = Decimal::new(speed.into(), 0);
+        speed_unscaled.checked_mul(SPEED_SCALAR).unwrap()
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn speed_upper_limit_roundtrip() {
+            let speed = Decimal::new(80_00, 2);
+            assert_eq!(speed.to_string(), "80.00");
+            let units = to_units(speed);
+            assert_eq!(80_00 / 25, units);
+            let speed = from_units(units);
+            assert_eq!(speed.to_string(), "80.00");
+        }
+
+        #[test]
+        fn speed_round_down() {
+            let altitude = Decimal::new(20_12, 2);
+            assert_eq!(altitude.to_string(), "20.12");
+            let altitude = from_units(to_units(altitude));
+            assert_eq!(altitude.to_string(), "20.00");
+        }
+
+        #[test]
+        fn speed_round_up() {
+            let altitude = Decimal::new(20_13, 2);
+            assert_eq!(altitude.to_string(), "20.13");
+            let altitude = from_units(to_units(altitude));
+            assert_eq!(altitude.to_string(), "20.25");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_latlon_from_degrees() {
+        // -122.281358
+        let degrees = Decimal::new(-122281358, 6);
+        let latlon_units = latlon_units_from_degrees(degrees);
+        // -12228136
+        assert_eq!(latlon_units, -12228136);
+    }
+
+    #[test]
+    fn hdop_roundtrip() {
+        let hdop = Decimal::new(123, 2);
+        assert_eq!(hdop.to_string(), "1.23"); // 1.23 m
+        let hdop_units = units_from_hdop(hdop);
+        assert_eq!(hdop_units, 123);
+        let hdop_roundtrip = hdop_from_units(hdop_units);
+        assert_eq!(hdop_roundtrip, hdop);
+    }
+
+    #[test]
+    /// The roundtrip is expected to round to the closes 0.25m
+    fn altitude_roundtrip() {
+        let altitude = Decimal::new(-4979, 2);
+        assert_eq!(altitude.to_string(), "-49.79"); // -49.79 m
+        let altitude_units = units_from_altitude(altitude);
+        assert_eq!(altitude_units, -4979 / 25);
+        let altitude_roundtrip = altitude_from_units(altitude_units);
+        assert_eq!(altitude_roundtrip.to_string(), "-49.75");
+    }
+
+    #[test]
+    /// The roundtrip is expected to round to the closes 0.25 km
+    fn speed_roundtrip() {
+        let speed = Decimal::new(5524, 2);
+        assert_eq!(speed.to_string(), "55.24"); // 55.24 km/h
+        let speed_units = units_from_speed(speed);
+        assert_eq!(speed_units, 5524 / 25 + 1);
+        let speed_roundtrip = speed_from_units(speed_units);
+        assert_eq!(speed_roundtrip.to_string(), "55.25");
+    }
+}

--- a/mapper/src/lib.rs
+++ b/mapper/src/lib.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+mod attach;
+pub use attach::*;
+
+mod gps;
+pub use gps::*;
+
+mod scan;
+pub use scan::*;
+
+mod ports;
+pub use ports::*;
+
+pub mod scan_beacon;
+
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("parse int error: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
+    #[error("unexpected attach result str: {0}")]
+    UnexpectedAttachResultStr(String),
+    #[error("h3o: {0}")]
+    H3o(#[from] h3o::error::InvalidLatLng),
+}
+

--- a/mapper/src/lib.rs
+++ b/mapper/src/lib.rs
@@ -1,3 +1,5 @@
+use chrono::{prelude::*, DateTime, NaiveDateTime};
+pub use helium_proto::Message;
 use serde::{Deserialize, Serialize};
 
 mod attach;
@@ -25,5 +27,6 @@ pub enum Error {
     UnexpectedAttachResultStr(String),
     #[error("h3o: {0}")]
     H3o(#[from] h3o::error::InvalidLatLng),
+    #[error("invalid attach result value: {value}")]
+    InvalidAttachResultInt { value: i32 },
 }
-

--- a/mapper/src/ports.rs
+++ b/mapper/src/ports.rs
@@ -1,0 +1,3 @@
+pub const ATTACH_PORT: u8 = 0x01;
+pub const SCAN_PORT: u8 = 0x02;
+pub const SCAN_BEACON_PORT: u8 = 0x10;

--- a/mapper/src/scan.rs
+++ b/mapper/src/scan.rs
@@ -25,30 +25,26 @@ pub struct ScanResult {
 pub struct AttachCandidate {
     pub from_scan: u32,
     pub delay: u32,
-    pub mcc: u16,
-    pub mnc: u16,
-    pub earfcn: u32,
-    pub physical_cell_id: u64,
+    pub cell_id: u32,
+    pub fcn: u16,
     pub rsrp: isize,
     pub rsrq: isize,
-    pub cell_id: u64,
+}
+
+impl From<ScanResult> for AttachCandidate {
+    fn from(scan_result: ScanResult) -> Self {
+        Self {
+            from_scan: 0,
+            delay: 0,
+            cell_id: scan_result.cell_id as u32,
+            fcn: scan_result.earfcn as u16,
+            rsrp: scan_result.rsrp,
+            rsrq: scan_result.rsrq,
+        }
+    }
 }
 
 impl ScanResult {
-    pub fn to_attach_candidate(&self, from_scan_response: u32, delay: u32) -> AttachCandidate {
-        AttachCandidate {
-            from_scan: from_scan_response,
-            delay,
-            mcc: self.mcc,
-            mnc: self.mnc,
-            earfcn: self.earfcn,
-            physical_cell_id: self.physical_cell_id,
-            rsrp: self.rsrp,
-            rsrq: self.rsrq,
-            cell_id: self.cell_id,
-        }
-    }
-
     pub fn is_our_network(&self) -> Result<bool> {
         if self.mcc == CBRS_MCC && self.mnc == CBRS_MNC {
             let top_20_bits = self.cell_id >> 8;

--- a/mapper/src/scan.rs
+++ b/mapper/src/scan.rs
@@ -6,70 +6,7 @@ use serde::Serialize;
 pub const CBRS_MCC: u16 = 315;
 pub const CBRS_MNC: u16 = 10;
 
-#[derive(Debug, Serialize, Clone)]
-pub struct ScanResult {
-    pub mcc: u16,
-    pub mnc: u16,
-    pub earfcn: u32,
-    pub physical_cell_id: u64,
-    pub rsrp: isize,
-    pub rsrq: isize,
-    pub rx_level: isize,
-    pub quality: usize,
-    pub cell_id: u64,
-    pub bandwidth: usize,
-    pub lte: bool,
-}
-
-#[derive(Debug, Serialize, Clone)]
-pub struct AttachCandidate {
-    pub from_scan: u32,
-    pub delay: u32,
-    pub cell_id: u32,
-    pub fcn: u16,
-    pub rsrp: isize,
-    pub rsrq: isize,
-}
-
-impl From<ScanResult> for AttachCandidate {
-    fn from(scan_result: ScanResult) -> Self {
-        Self {
-            from_scan: 0,
-            delay: 0,
-            cell_id: scan_result.cell_id as u32,
-            fcn: scan_result.earfcn as u16,
-            rsrp: scan_result.rsrp,
-            rsrq: scan_result.rsrq,
-        }
-    }
-}
-
-impl ScanResult {
-    pub fn is_our_network(&self) -> Result<bool> {
-        if self.mcc == CBRS_MCC && self.mnc == CBRS_MNC {
-            let top_20_bits = self.cell_id >> 8;
-            // Helium cells all have a prefix in this range
-            Ok((0x0099D..=0x00A00).contains(&top_20_bits))
-        } else {
-            Ok(false)
-        }
-    }
-}
-
-impl From<ScanResult> for helium_proto::MapperScanResult {
-    fn from(scan_result: ScanResult) -> Self {
-        Self {
-            cid: scan_result.cell_id,
-            plmn: ((scan_result.mcc as u32) << 16) | scan_result.mnc as u32,
-            fcn: scan_result.earfcn,
-            pci: scan_result.physical_cell_id as u32,
-            rsrp: (scan_result.rsrp * 100) as i32,
-            rsrq: (scan_result.rsrq * 100) as i32,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct ScanResults {
     pub scan_counter: u32,
     pub gps: GpsData,
@@ -90,4 +27,116 @@ impl From<ScanResults> for helium_proto::MapperScanV1 {
     }
 }
 
+impl From<helium_proto::MapperScanV1> for ScanResults {
+    fn from(scan_response: helium_proto::MapperScanV1) -> Self {
+        Self {
+            scan_counter: scan_response.scan_counter,
+            gps: scan_response.gps.unwrap().into(),
+            results: scan_response
+                .results
+                .into_iter()
+                .map(|r| r.into())
+                .collect(),
+        }
+    }
+}
 
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct ScanResult {
+    pub mcc: u16,
+    pub mnc: u16,
+    pub earfcn: u32,
+    pub physical_cell_id: u64,
+    pub rsrp: i32,
+    pub rsrq: i32,
+    pub cell_id: u64,
+    pub bandwidth: u32,
+    pub lte: bool,
+}
+
+impl ScanResult {
+    pub fn is_our_network(&self) -> Result<bool> {
+        if self.mcc == CBRS_MCC && self.mnc == CBRS_MNC {
+            let top_20_bits = self.cell_id >> 8;
+            // Helium cells all have a prefix in this range
+            Ok((0x0099D..=0x00A00).contains(&top_20_bits))
+        } else {
+            Ok(false)
+        }
+    }
+
+    #[cfg(test)]
+    pub fn random() -> Self {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        Self {
+            mcc: rng.gen_range(0..999),
+            mnc: rng.gen_range(0..999),
+            cell_id: rng.gen_range(0..68719476735),
+            earfcn: rng.gen_range(0..4294967295),
+            rsrp: rng.gen_range(-144..-44),
+            rsrq: rng.gen_range(-20..-3),
+            physical_cell_id: rng.gen_range(0..503),
+            bandwidth: rng.gen_range(0..4294967295),
+            lte: true,
+        }
+    }
+}
+
+impl From<ScanResult> for helium_proto::MapperScanResult {
+    fn from(scan_result: ScanResult) -> Self {
+        Self {
+            lte: scan_result.lte,
+            cid: scan_result.cell_id,
+            plmn: ((scan_result.mcc as u32) << 16) | scan_result.mnc as u32,
+            fcn: scan_result.earfcn,
+            pci: scan_result.physical_cell_id as u32,
+            rsrp: scan_result.rsrp,
+            rsrq: scan_result.rsrq,
+            bandwidth: scan_result.bandwidth,
+        }
+    }
+}
+
+impl From<helium_proto::MapperScanResult> for ScanResult {
+    fn from(scan_result: helium_proto::MapperScanResult) -> Self {
+        Self {
+            lte: scan_result.lte,
+            cell_id: scan_result.cid,
+            mcc: (scan_result.plmn >> 16) as u16,
+            mnc: scan_result.plmn as u16,
+            earfcn: scan_result.fcn,
+            physical_cell_id: scan_result.pci as u64,
+            rsrp: scan_result.rsrp,
+            rsrq: scan_result.rsrq,
+            bandwidth: scan_result.bandwidth,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use helium_proto::Message;
+
+    #[test]
+    fn scan_roundtrip_proto() {
+        let mut results = Vec::new();
+        for _ in 0..40 {
+            results.push(ScanResult::random());
+        }
+        let scan_results = ScanResults {
+            scan_counter: 24,
+            gps: GpsData::rounded(),
+            results,
+        };
+        let proto: helium_proto::MapperScanV1 = scan_results.clone().into();
+
+        let mut proto_bytes = Vec::new();
+        proto.encode(&mut proto_bytes).unwrap();
+        let scan_results_returned = helium_proto::MapperScanV1::decode(proto_bytes.as_slice())
+            .unwrap()
+            .into();
+        assert_eq!(scan_results, scan_results_returned);
+    }
+}

--- a/mapper/src/scan.rs
+++ b/mapper/src/scan.rs
@@ -1,0 +1,97 @@
+use super::Result;
+
+use crate::GpsData;
+use serde::Serialize;
+
+pub const CBRS_MCC: u16 = 315;
+pub const CBRS_MNC: u16 = 10;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ScanResult {
+    pub mcc: u16,
+    pub mnc: u16,
+    pub earfcn: u32,
+    pub physical_cell_id: u64,
+    pub rsrp: isize,
+    pub rsrq: isize,
+    pub rx_level: isize,
+    pub quality: usize,
+    pub cell_id: u64,
+    pub bandwidth: usize,
+    pub lte: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct AttachCandidate {
+    pub from_scan: u32,
+    pub delay: u32,
+    pub mcc: u16,
+    pub mnc: u16,
+    pub earfcn: u32,
+    pub physical_cell_id: u64,
+    pub rsrp: isize,
+    pub rsrq: isize,
+    pub cell_id: u64,
+}
+
+impl ScanResult {
+    pub fn to_attach_candidate(&self, from_scan_response: u32, delay: u32) -> AttachCandidate {
+        AttachCandidate {
+            from_scan: from_scan_response,
+            delay,
+            mcc: self.mcc,
+            mnc: self.mnc,
+            earfcn: self.earfcn,
+            physical_cell_id: self.physical_cell_id,
+            rsrp: self.rsrp,
+            rsrq: self.rsrq,
+            cell_id: self.cell_id,
+        }
+    }
+
+    pub fn is_our_network(&self) -> Result<bool> {
+        if self.mcc == CBRS_MCC && self.mnc == CBRS_MNC {
+            let top_20_bits = self.cell_id >> 8;
+            // Helium cells all have a prefix in this range
+            Ok((0x0099D..=0x00A00).contains(&top_20_bits))
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl From<ScanResult> for helium_proto::MapperScanResult {
+    fn from(scan_result: ScanResult) -> Self {
+        Self {
+            cid: scan_result.cell_id,
+            plmn: ((scan_result.mcc as u32) << 16) | scan_result.mnc as u32,
+            fcn: scan_result.earfcn,
+            pci: scan_result.physical_cell_id as u32,
+            rsrp: (scan_result.rsrp * 100) as i32,
+            rsrq: (scan_result.rsrq * 100) as i32,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ScanResults {
+    pub scan_counter: u32,
+    pub gps: GpsData,
+    pub results: Vec<ScanResult>,
+}
+
+impl From<ScanResults> for helium_proto::MapperScanV1 {
+    fn from(scan_response: ScanResults) -> Self {
+        Self {
+            scan_counter: scan_response.scan_counter,
+            gps: Some(scan_response.gps.into()),
+            results: scan_response
+                .results
+                .into_iter()
+                .map(|r| r.into())
+                .collect(),
+        }
+    }
+}
+
+

--- a/mapper/src/scan_beacon.rs
+++ b/mapper/src/scan_beacon.rs
@@ -1,0 +1,120 @@
+use super::gps::{hdop, latlon, time, altitude, speed};
+use crate::GpsData;
+use modular_bitfield_msb::{bitfield, specifiers::*};
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct ScanBeacon {
+    gps: GpsData,
+    hash: Vec<u8>,
+}
+
+impl ScanBeacon {
+    pub fn new(gps: GpsData, signature: Vec<u8>) -> Self {
+        Self {
+            gps,
+            hash: signature,
+        }
+    }
+
+    pub fn into_bytes(self) -> [u8; 17] {
+        let lora_payload: LoraPayload = self.into();
+        lora_payload.into_bytes()
+    }
+
+    pub fn from_bytes(bytes: [u8; 17]) -> Self {
+        let lora_payload = LoraPayload::from_bytes(bytes);
+        lora_payload.into()
+    }
+}
+
+impl From<LoraPayload> for ScanBeacon {
+    fn from(lora_payload: LoraPayload) -> Self {
+        use latlon::Unit;
+        Self {
+            gps: GpsData {
+                timestamp: time::from_units(lora_payload.time()),
+                lat: latlon::from_units(Unit::Lat(lora_payload.lat())),
+                lon: latlon::from_units(Unit::Lon(lora_payload.lon())),
+                hdop: hdop::from_units(lora_payload.hdop().into()),
+                altitude: altitude::from_units(lora_payload.alt().into()),
+                num_sats: lora_payload.num_sats(),
+                speed: speed::from_units(lora_payload.speed().into()),
+            },
+            hash: lora_payload.hash().to_be_bytes().to_vec(),
+        }
+    }
+}
+
+impl From<ScanBeacon> for LoraPayload {
+    fn from(p: ScanBeacon) -> Self {
+        use latlon::Degrees;
+        LoraPayload::new()
+            .with_time(time::to_units(p.gps.timestamp))
+            .with_lat(latlon::to_units(Degrees::Lat(p.gps.lat)))
+            .with_lon(latlon::to_units(Degrees::Lon(p.gps.lon)))
+            .with_hdop(hdop::to_units(p.gps.hdop) as u16)
+            .with_alt(altitude::to_units(p.gps.altitude) as u16)
+            .with_speed(speed::to_units(p.gps.speed) as u16)
+            .with_num_sats(p.gps.num_sats)
+            .with_hash(u16::from_be_bytes([p.hash[0], p.hash[1]]))
+    }
+}
+
+#[bitfield]
+struct LoraPayload {
+    // we take seconds from 2023-01-01 00:00:00 UTC
+    // 30 bits gives us over 20 years
+    time: B30,
+    // lat ranges from -90 to 90 w/ 5 decimal places (1.11 m accuracy)
+    // shifted to a uint, ranges up to 18000000 => 25 bits
+    lat: B25,
+    // lon ranges from -180 to 180 w/ 5 decimal places (1.11 m accuracy)
+    // shifted to a uint, ranges up to 36000000 => 26 bits
+    lon: B26,
+    // we will not send HDOP values greater than 10m
+    // 0.01m increments => 1000 possible values => 10 bits
+    hdop: B10,
+    // WGS-84 on the surface of earth ranges from +85m (Iceland) to -106m (India)
+    // (https://en.wikipedia.org/wiki/Geoid)
+    // We will represent this in 0.25m steps shifted to a uint by 110m => 0-780 values => 10 bits
+    alt: B10,
+    // Will never exceed 80 km/h. We will represent in 0.25m/h steps => 0-320 values => 9 bits
+    speed: B9,
+    // 0-12 sats => 4 bits
+    num_sats: B4,
+    // truncated signature of the scan payload
+    hash: B16,
+    // padding for the struct is necessary to make it byte aligned
+    #[allow(unused)]
+    padding: B6,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn payload_roundtrip() {
+        use chrono::TimeZone;
+        let timestamp = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 5).unwrap();
+
+        let payload = ScanBeacon {
+            gps: GpsData {
+                timestamp,
+                lat: Decimal::new(-50_12345, 5),
+                lon: Decimal::new(120_12345, 5),
+                hdop: Decimal::new(10_05, 2),
+                altitude: Decimal::new(10_25, 2),
+                num_sats: 5,
+                speed: Decimal::new(50_50, 2),
+            },
+            hash: vec![0xAB, 0xCD],
+        };
+        let lora_payload = LoraPayload::from(payload.clone());
+        let bytes = lora_payload.into_bytes();
+        let payload_returned = ScanBeacon::from_bytes(bytes);
+        assert_eq!(payload, payload_returned);
+    }
+}
+
+

--- a/src/mapper.proto
+++ b/src/mapper.proto
@@ -70,18 +70,23 @@ message mapper_gps {
 }
 
 message mapper_gps_v1 {
-  // Unix time in seconds
-  uint32 unix_time = 1;
-  // Latitude of the current base station in units of 0.25 sec.
-  int32 lat = 2;
-  // Longitude of the current base station in units of 0.25 sec.
-  int32 lon = 3;
-  // Horizontal dilution of position in units of 0.01 HDOP.
+  // we take seconds from 2023-01-01 00:00:00 UTC
+  uint32 timestamp = 1;
+  // lat ranges from -90 to 90 w/ 5 decimal places (1.11 m accuracy)
+  // shifted to a uint
+  uint32 lat = 2;
+  // lon ranges from -180 to 180 w/ 5 decimal places (1.11 m accuracy)
+  // shifted to a uint
+  uint32 lon = 3;
+  // given in 0.01m increments
   uint32 hdop = 4;
-  // Altitude in units of 0.25m above the WGS 84 reference ellipsoid.
-  int64 altitude = 5;
-  int32 num_sats = 6;
-  // Speed in speed in 0.25m/s per second.
+  // WGS-84 on the surface of earth ranges from +85m (Iceland) to -106m (India)
+  // (https://en.wikipedia.org/wiki/Geoid)
+  // We will represent this in 0.25m steps shifted to a uint by 110m
+  uint32 altitude = 5;
+  // number of satellites used for fix
+  uint32 num_sats = 6;
+  // Speed 0.25m/s increments
   uint32 speed = 7;
 }
 

--- a/src/mapper.proto
+++ b/src/mapper.proto
@@ -41,7 +41,7 @@ message mapper_attach_v1 {
   message mapper_attach_candidate {
     // Corresponds "scan_response_counter" in the scan_response_counter which we
     // selected attach candidates from
-    uint32 from_scan_response = 2;
+    uint32 from_scan = 2;
     // delay in seconds between locking to the cell and evaluating connectivity
     uint32 delay = 3;
     uint32 fcn = 4;
@@ -64,23 +64,19 @@ message mapper_gps {
 }
 
 message mapper_gps_v1 {
-  // we take seconds from 2023-01-01 00:00:00 UTC
-  uint32 timestamp = 1;
-  // lat ranges from -90 to 90 w/ 5 decimal places (1.11 m accuracy)
-  // shifted to a uint
-  uint32 lat = 2;
-  // lon ranges from -180 to 180 w/ 5 decimal places (1.11 m accuracy)
-  // shifted to a uint
-  uint32 lon = 3;
-  // given in 0.01m increments
+  // epoch UTC time in seconds
+  uint64 timestamp = 1;
+  // given in 0.00001 degrees
+  int32 lat = 2;
+  // given in 0.00001 degrees
+  int32 lon = 3;
+  // given in 0.01m
   uint32 hdop = 4;
-  // WGS-84 on the surface of earth ranges from +85m (Iceland) to -106m (India)
-  // (https://en.wikipedia.org/wiki/Geoid)
-  // We will represent this in 0.25m steps shifted to a uint by 110m
-  uint32 altitude = 5;
+  // given in 0.01m
+  int32 altitude = 5;
   // number of satellites used for fix
   uint32 num_sats = 6;
-  // Speed 0.25m/s increments
+  // given in 0.01m
   uint32 speed = 7;
 }
 
@@ -95,15 +91,18 @@ message mapper_scan_v1 {
 }
 
 message mapper_scan_result {
+  bool lte = 1;
   // 28-bit (UMTS, LTE) or 36-bit (5G NR)
-  uint64 cid = 1;
+  uint64 cid = 2;
   // PLMN = (MCC << 16) | MNC
-  uint32 plmn = 2;
+  uint32 plmn = 3;
   // EARFCN or UARFCN
-  uint32 fcn = 3;
-  uint32 pci = 4;
+  uint32 fcn = 4;
+  uint32 pci = 5;
   // RSRQ in units of 0.1 dB
-  int32 rsrp = 5;
+  int32 rsrp = 6;
   // RSRP in units of 0.1 dBm
-  int32 rsrq = 6;
+  int32 rsrq = 7;
+  // bandwidth in MHz
+  uint32 bandwidth = 8;
 }

--- a/src/mapper.proto
+++ b/src/mapper.proto
@@ -39,24 +39,18 @@ message mapper_attach_v1 {
     no_network_service = 5;
   }
   message mapper_attach_candidate {
-    enum cell_tech {
-      lte = 0;
-      nr = 1;
-    }
-    cell_tech type = 1;
     // Corresponds "scan_response_counter" in the scan_response_counter which we
     // selected attach candidates from
     uint32 from_scan_response = 2;
     // delay in seconds between locking to the cell and evaluating connectivity
     uint32 delay = 3;
-    uint32 plmn = 4;
-    uint32 fcn = 5;
-    // 28-bit (UMTS, LTE) or 36-bit (5G NR)
-    uint64 cid = 6;
+    uint32 fcn = 4;
+    // 28-bit (UMTS, LTE)
+    uint32 cid = 5;
     // RSRQ in units of 0.1 dB
-    int32 rsrp = 7;
+    int32 rsrp = 6;
     // RSRP in units of 0.1 dBm
-    int32 rsrq = 8;
+    int32 rsrq = 7;
   }
   // This allows us to detect censorship efforts. It can roll over.
   uint32 attach_counter = 1;


### PR DESCRIPTION
Provides handwritten Rust types for Mapper messages so as to provide more specific types for the fields.

Also includes lora payload ser/deser for Attach and ScanBeacon.