### PR TITLE
allow adding pcs keys to mobile config

### DIFF
--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -90,6 +90,8 @@ enum admin_key_role {
   oracle = 2;
   // carrier authorizing keys for signing mobile subscriber activity
   carrier = 3;
+  // propagation calculation service of a mobile carrier
+  pcs = 4;
 }
 
 enum network_key_role {


### PR DESCRIPTION
allow adding PCS (propagation calculation service) keys to the mobile config service to verify carrier PCS report signatures during mobile verification