### PR TITLE
Add lat and lon to heartbeat output since we validate them

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -173,10 +173,10 @@ message heartbeat {
   uint64 timestamp = 4;
   cell_type cell_type = 5;
   heartbeat_validity validity = 6;
-  double lat = 6;
-  double lon = 7;
+  double lat = 7;
+  double lon = 8;
   // UUID of the coverage object associated with this heartbeat
-  bytes coverage_object = 8;
+  bytes coverage_object = 9;
 }
 
 enum heartbeat_validity {


### PR DESCRIPTION
These fields aren't used as of right now so I kept them in the order that is in the heartbeat.
Should have just embedded the object at the start :pensive: 