### PR TITLE
No harm no foul, completely remove coverage objects from radio reward

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -260,9 +260,6 @@ message radio_reward {
   uint64 poc_reward = 4;
   // Accumulated coverage points for the radio
   uint64 coverage_points = 5;
-  // Coverage objects claimed to make this calculation.
-  // This will always be empty
-  repeated bytes coverage_objects = 6 [ deprecated = true ];
 }
 
 message gateway_reward {


### PR DESCRIPTION
Since we defaulted this value in all of our output, we can safely remove this. Any new field will default for the output 