### PR TITLE
support invalid details for invalid beacons and witnesses

### DIFF
--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -160,6 +160,9 @@ message lora_invalid_beacon_report_v1 {
   /// The asserted elevation of the gateway in AGL ( above ground level)
   /// derived from gateway metadata
   int32 elevation = 6;
+  // provides any additional context for invalid reason
+  // for example the deny list version used as part of the deny list check
+  string invalid_details = 7;
 }
 
 // tagged invalid witness report produced by the verifier
@@ -171,6 +174,9 @@ message lora_invalid_witness_report_v1 {
   // the participant to which the reason applies,
   // which rendered the report as invalid
   invalid_participant_side participant_side = 4;
+  // provides any additional context for invalid reason
+  // for example the deny list version used as part of the deny list check
+  string invalid_details = 5;
 }
 
 // tagged verified witness report produced by the verifier
@@ -196,6 +202,9 @@ message lora_verified_witness_report_v1 {
   /// The asserted elevation of the gateway in AGL ( above ground level)
   /// derived from gateway metadata
   int32 elevation = 10;
+  // provides any additional context for invalid reason
+  // for example the deny list version used as part of the deny list check
+  string invalid_details = 11;
 }
 
 // POC report produced by the verifier

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -145,6 +145,10 @@ message lora_valid_witness_report_v1 {
   uint32 reward_unit = 5;
 }
 
+message invalid_details {
+  oneof data { string denied = 1; }
+}
+
 // tagged invalid beacon report produced by the verifier
 message lora_invalid_beacon_report_v1 {
   // Timestamp at ingest in millis since unix epoch
@@ -162,7 +166,7 @@ message lora_invalid_beacon_report_v1 {
   int32 elevation = 6;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  oneof invalid_details { string denied = 7; }
+  invalid_details invalid_details = 7;
 }
 
 // tagged invalid witness report produced by the verifier
@@ -176,7 +180,7 @@ message lora_invalid_witness_report_v1 {
   invalid_participant_side participant_side = 4;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  oneof invalid_details { string denied = 5; }
+  invalid_details invalid_details = 5;
 }
 
 // tagged verified witness report produced by the verifier
@@ -204,7 +208,7 @@ message lora_verified_witness_report_v1 {
   int32 elevation = 10;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  oneof invalid_details { string denied = 11; }
+  invalid_details invalid_details = 11;
 }
 
 // POC report produced by the verifier

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -166,7 +166,7 @@ message lora_invalid_beacon_report_v1 {
   int32 elevation = 6;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details details = 7;
+  invalid_details invalid_details = 7;
 }
 
 // tagged invalid witness report produced by the verifier
@@ -180,7 +180,7 @@ message lora_invalid_witness_report_v1 {
   invalid_participant_side participant_side = 4;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details details = 5;
+  invalid_details invalid_details = 5;
 }
 
 // tagged verified witness report produced by the verifier
@@ -208,7 +208,7 @@ message lora_verified_witness_report_v1 {
   int32 elevation = 10;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details details = 11;
+  invalid_details invalid_details = 11;
 }
 
 // POC report produced by the verifier

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -146,7 +146,7 @@ message lora_valid_witness_report_v1 {
 }
 
 message invalid_details {
-  oneof data { string denied = 1; }
+  oneof data { string denylist_tag = 1; }
 }
 
 // tagged invalid beacon report produced by the verifier
@@ -166,7 +166,7 @@ message lora_invalid_beacon_report_v1 {
   int32 elevation = 6;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details invalid_details = 7;
+  invalid_details details = 7;
 }
 
 // tagged invalid witness report produced by the verifier
@@ -180,7 +180,7 @@ message lora_invalid_witness_report_v1 {
   invalid_participant_side participant_side = 4;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details invalid_details = 5;
+  invalid_details details = 5;
 }
 
 // tagged verified witness report produced by the verifier
@@ -208,7 +208,7 @@ message lora_verified_witness_report_v1 {
   int32 elevation = 10;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  invalid_details invalid_details = 11;
+  invalid_details details = 11;
 }
 
 // POC report produced by the verifier

--- a/src/service/poc_lora.proto
+++ b/src/service/poc_lora.proto
@@ -162,7 +162,7 @@ message lora_invalid_beacon_report_v1 {
   int32 elevation = 6;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  string invalid_details = 7;
+  oneof invalid_details { string denied = 7; }
 }
 
 // tagged invalid witness report produced by the verifier
@@ -176,7 +176,7 @@ message lora_invalid_witness_report_v1 {
   invalid_participant_side participant_side = 4;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  string invalid_details = 5;
+  oneof invalid_details { string denied = 5; }
 }
 
 // tagged verified witness report produced by the verifier
@@ -204,7 +204,7 @@ message lora_verified_witness_report_v1 {
   int32 elevation = 10;
   // provides any additional context for invalid reason
   // for example the deny list version used as part of the deny list check
-  string invalid_details = 11;
+  oneof invalid_details { string denied = 11; }
 }
 
 // POC report produced by the verifier


### PR DESCRIPTION
Adds an invalid_details field which can be populated with context on why a POC report was declared invalid.  The invalid_details value should be descriptive and add additional value to the denied reason.
