### PR TITLE
Add fields to heartbeat and mobile_reward_share files to help understand how rewards are calculated

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -214,7 +214,7 @@ message heartbeat {
   string cbsd_id = 1;
   bytes pub_key = 2;
   // this value is the heartbeat_multiplier * location_trust_score_multiplier
-  float reward_multiplier = 3;
+  float reward_multiplier = 3 [ deprecated = true ];
   uint64 timestamp = 4;
   cell_type cell_type = 5;
   heartbeat_validity validity = 6;
@@ -228,8 +228,6 @@ message heartbeat {
   // Distance in meters to the asserted location of the gateway_reward
   // at the time of heartbeat verification
   uint64 distance_to_asserted = 11;
-  // based on cell_type of radio
-  float heartbeat_multiplier = 12;
   // only used for wifi indoor radios, all others should have a value of 1.0
   float location_trust_score_multiplier = 13;
 }
@@ -326,8 +324,6 @@ message radio_reward {
   uint64 seniority_timestamp = 6;
   // UUID of the coverage object used to reward this radio
   bytes coverage_object = 7;
-  // based on number of heartbeats received and cell_type
-  float heartbeat_multiplier = 8;
   // only used for wifi indoor radios, all others should have a value of 1.0
   float location_trust_score_multiplier = 9;
   // based on speedtest averages of speedtests during 48 hour period from end of

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -213,6 +213,7 @@ message heartbeat {
   // applicable to cell heartbeats only
   string cbsd_id = 1;
   bytes pub_key = 2;
+  // this value is the heartbeat_multiplier * location_trust_score_multiplier
   float reward_multiplier = 3;
   uint64 timestamp = 4;
   cell_type cell_type = 5;
@@ -227,6 +228,10 @@ message heartbeat {
   // Distance in meters to the asserted location of the gateway_reward
   // at the time of heartbeat verification
   uint64 distance_to_asserted = 11;
+  // based on cell_type of radio
+  float heartbeat_multiplier = 12;
+  // only used for wifi indoor radios, all others should have a value of 1.0
+  float location_trust_score_multiplier = 13;
 }
 
 enum heartbeat_validity {
@@ -321,6 +326,12 @@ message radio_reward {
   uint64 seniority_timestamp = 6;
   // UUID of the coverage object used to reward this radio
   bytes coverage_object = 7;
+  // based on number of heartbeats received and cell_type
+  float heartbeat_multiplier = 8;
+  // only used for wifi indoor radios, all others should have a value of 1.0
+  float location_trust_score_multiplier = 9;
+  // based on speedtest averages of speedtests during 48 hour period from end of rewardable period
+  float speedtest_multiplier = 10;
 }
 
 message gateway_reward {
@@ -328,6 +339,10 @@ message gateway_reward {
   bytes hotspot_key = 1;
   /// Amount awarded for dc transfer
   uint64 dc_transfer_reward = 2;
+  /// count of rewardable bytes transfered 
+  uint64 rewardable_bytes = 3;
+  /// Price of MOBILE used when calculating rewards
+  uint64 price = 4;
 }
 
 message subscriber_reward {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -229,7 +229,8 @@ message heartbeat {
   // at the time of heartbeat verification
   uint64 distance_to_asserted = 11;
   // only used for wifi indoor radios, all others should have a value of 1.0
-  float location_trust_score_multiplier = 13;
+  // value is 0.0 to 1.0 multiplied by 1000
+  uint32 location_trust_score_multiplier = 12;
 }
 
 enum heartbeat_validity {
@@ -325,10 +326,12 @@ message radio_reward {
   // UUID of the coverage object used to reward this radio
   bytes coverage_object = 7;
   // only used for wifi indoor radios, all others should have a value of 1.0
-  float location_trust_score_multiplier = 9;
+  // value is 0.0 to 1.0 multiplied by 1000
+  uint32 location_trust_score_multiplier = 8;
   // based on speedtest averages of speedtests during 48 hour period from end of
   // rewardable period
-  float speedtest_multiplier = 10;
+  // value is 0.0 to 1.0 multiplied by 1000
+  uint32 speedtest_multiplier = 9;
 }
 
 message gateway_reward {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -330,7 +330,8 @@ message radio_reward {
   float heartbeat_multiplier = 8;
   // only used for wifi indoor radios, all others should have a value of 1.0
   float location_trust_score_multiplier = 9;
-  // based on speedtest averages of speedtests during 48 hour period from end of rewardable period
+  // based on speedtest averages of speedtests during 48 hour period from end of
+  // rewardable period
   float speedtest_multiplier = 10;
 }
 
@@ -339,7 +340,7 @@ message gateway_reward {
   bytes hotspot_key = 1;
   /// Amount awarded for dc transfer
   uint64 dc_transfer_reward = 2;
-  /// count of rewardable bytes transfered 
+  /// count of rewardable bytes transfered
   uint64 rewardable_bytes = 3;
   /// Price of MOBILE used when calculating rewards
   uint64 price = 4;

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -342,7 +342,7 @@ message gateway_reward {
   uint64 dc_transfer_reward = 2;
   /// count of rewardable bytes transfered
   uint64 rewardable_bytes = 3;
-  /// Price of MOBILE used when calculating rewards
+  /// Price of MOBILE @ 10^6 used when calculating rewards
   uint64 price = 4;
 }
 


### PR DESCRIPTION
In troubleshooting various issues, I realized how valuable having all the multipliers be recorded in the mobile_verifier outputs would be. 