### PR TITLE
make ics response timestamps consistent with request timestamps

### DIFF
--- a/src/service/iot_config.proto
+++ b/src/service/iot_config.proto
@@ -140,7 +140,7 @@ message org_list_req_v1 {}
 
 message org_list_res_v1 {
   repeated org_v1 orgs = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -208,6 +208,7 @@ message org_update_req_v1 {
 
   uint64 oui = 1;
   repeated update_v1 updates = 2;
+  // in milliseconds since unix epoch
   uint64 timestamp = 3;
   bytes signer = 4;
   bytes signature = 5;
@@ -217,7 +218,7 @@ message org_res_v1 {
   org_v1 org = 1;
   uint32 net_id = 2;
   repeated devaddr_constraint_v1 devaddr_constraints = 3;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 4;
   // pubkey binary of the signing keypair
   bytes signer = 5;
@@ -236,7 +237,7 @@ message org_disable_req_v1 {
 
 message org_disable_res_v1 {
   uint64 oui = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -255,7 +256,7 @@ message org_enable_req_v1 {
 
 message org_enable_res_v1 {
   uint64 oui = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -274,7 +275,7 @@ message route_list_req_v1 {
 
 message route_list_res_v1 {
   repeated route_v1 routes = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -321,7 +322,7 @@ message route_delete_req_v1 {
 
 message route_res_v1 {
   route_v1 route = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -349,7 +350,7 @@ message route_update_euis_req_v1 {
 }
 
 message route_euis_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -377,7 +378,7 @@ message route_update_devaddr_ranges_req_v1 {
 }
 
 message route_devaddr_ranges_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -397,7 +398,7 @@ message route_stream_req_v1 {
 }
 
 message route_stream_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -459,7 +460,7 @@ message route_skf_update_req_v1 {
 }
 
 message route_skf_update_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -479,7 +480,7 @@ message gateway_region_params_res_v1 {
   uint64 gain = 3;
   // Signature over the response by the config service
   bytes signature = 4;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 5;
   // pubkey binary of the signing keypair
   bytes signer = 6;
@@ -494,7 +495,7 @@ message gateway_location_req_v1 {
 
 message gateway_location_res_v1 {
   string location = 1;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 2;
   // pubkey binary of the signing keypair
   bytes signer = 3;
@@ -514,7 +515,7 @@ message admin_load_region_req_v1 {
 }
 
 message admin_load_region_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -551,7 +552,7 @@ message admin_remove_key_req_v1 {
 }
 
 message admin_key_res_v1 {
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 1;
   // pubkey binary of the signing keypair
   bytes signer = 2;
@@ -591,7 +592,7 @@ message gateway_info_req_v1 {
 }
 
 message gateway_info_res_v1 {
-  /// Timestamp of response in seconds since unix epoch
+  /// Timestamp of response in milliseconds since unix epoch
   uint64 timestamp = 1;
   gateway_info info = 2;
   /// sig from the config service
@@ -611,7 +612,7 @@ message gateway_info_stream_req_v1 {
 
 /// Active gateway info streaming response containing a batch of gateways
 message gateway_info_stream_res_v1 {
-  /// Timestamp of response in seconds since unix epoch
+  /// Timestamp of response in milliseconds since unix epoch
   uint64 timestamp = 1;
   /// batch of gateways
   repeated gateway_info gateways = 2;
@@ -636,7 +637,7 @@ message region_params_res_v1 {
   bytes signature = 3;
   // pubkey binary of the signing keypair
   bytes signer = 4;
-  // in seconds since unix epoch
+  // in milliseconds since unix epoch
   uint64 timestamp = 5;
 }
 


### PR DESCRIPTION
ensure the response timestamps attached to iot-config service rpcs are consistent with the expected millisecond precision of the input requests