### PR TITLE
Update comment to include wifi outdoor

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -229,7 +229,7 @@ message heartbeat {
   // Distance in meters to the asserted location of the gateway_reward
   // at the time of heartbeat verification
   uint64 distance_to_asserted = 11;
-  // only used for wifi indoor radios, all others should have a value of 1.0
+  // only used for wifi radios, all others should have a value of 1.0
   // value is 0.0 to 1.0 multiplied by 1000
   uint32 location_trust_score_multiplier = 12;
 }
@@ -328,7 +328,7 @@ message radio_reward {
   uint64 seniority_timestamp = 6;
   // UUID of the coverage object used to reward this radio
   bytes coverage_object = 7;
-  // only used for wifi indoor radios, all others should have a value of 1.0
+  // only used for wifi radios, all others should have a value of 1.0
   // value is 0.0 to 1.0 multiplied by 1000
   uint32 location_trust_score_multiplier = 8;
   // based on speedtest averages of speedtests during 48 hour period from end of


### PR DESCRIPTION
`location_trust_score_multiplier` is said to be working for both indoor and outdoor wifi. Updating the comment accordingly