### PR TITLE
Updating comment for invalidated_radio_threshold_report_req_v1 timestamp

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -178,7 +178,7 @@ message invalidated_radio_threshold_report_req_v1 {
   bytes hotspot_pubkey = 2;
   // the reason the thresholds are invalidated
   invalidated_threshold_reason reason = 3;
-  // Timestamp in milliseconds since unix epoch
+  // Timestamp in seconds since unix epoch
   // of when the thresholds were invalidated
   uint64 timestamp = 4;
   // pubkey of the carrier identity service


### PR DESCRIPTION
The comment states the `timestamp` field of `invalidated_radio_threshold_report_req_v1` message is in milliseconds but the data shows that it is in seconds: 

```
verified_invalidated_radio_threshold_ingest_report_v1 {
  status: 0,
  timestamp: 1709986943271n,
  report: invalidated_radio_threshold_ingest_report_v1 {
    receivedTimestamp: 1709986005909n,
    report: invalidated_radio_threshold_report_req_v1 {
      cbsdId: '',
      hotspotPubkey: <Buffer 04 01 03 01 00 b4 f5 e0 a9 e9 49 ae 51 42 bc f5 b6 5e 1b d7 fb ef 87 14 ad 85 00 40 b4 17 b6 24 9c 6e a4 76 28 fd 0b d0 49 41 54 2f 32 c2 c5 f4 93 90 ... 214 more bytes>,
      reason: 0,
      timestamp: 1709985995n,
      carrierPubKey: <Buffer 01 9e 2e 85 d5 8c c4 d7 d9 4c ae 87 45 ae c6 bd fc 9b e6 0f bd 2f da bf 37 e3 38 4d 6c 9f 58 09 1a>,
      signature: Uint8Array(0) []
    }
  }
}
```