### PR TITLE
Add `boosted_hex_device_type_v1` for HIP-109

### DIFF
--- a/src/hex_boosting.proto
+++ b/src/hex_boosting.proto
@@ -23,6 +23,8 @@ message boosted_hex_info_v1 {
   bytes boost_config_pubkey = 7;
 
   uint32 version = 8;
+  // The device type(s) this boost applies to.
+  boosted_hex_device_type_v1 device_type = 9;
 }
 
 message boosted_hex_update_v1 {
@@ -30,4 +32,12 @@ message boosted_hex_update_v1 {
   uint64 timestamp = 1;
   // Details of the updated hex
   boosted_hex_info_v1 update = 2;
+}
+
+enum boosted_hex_device_type_v1 {
+  all = 0;
+  cbrs_indoor = 1;
+  cbrs_outdoor = 2;
+  wifi_indoor = 3;
+  wifi_outdoor = 4;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ pub use prost::{DecodeError, EncodeError, Message};
 #[cfg(feature = "services")]
 pub mod services {
     use crate::{
-        BlockchainRegionParamsV1, BlockchainTokenTypeV1, BlockchainTxn, BoostedHexInfoV1,
-        BoostedHexUpdateV1, DataRate, EntropyReportV1, GatewayStakingMode, MapperAttach, Region,
-        RoutingAddress, ServiceProvider,
+        BlockchainRegionParamsV1, BlockchainTokenTypeV1, BlockchainTxn, BoostedHexDeviceTypeV1,
+        BoostedHexInfoV1, BoostedHexUpdateV1, DataRate, EntropyReportV1, GatewayStakingMode,
+        MapperAttach, Region, RoutingAddress, ServiceProvider,
     };
 
     pub mod iot_config {


### PR DESCRIPTION
The first iteration of HIP-109[1] adds the ability to boost by a device type. Pre-existing boosts will continue to boost _all_ device types.

From the way the HIP reads, at some point, a hex may be boosted by the same provider for multiple device types. It was undecided wether that would be implemented as multiple device_types attached to a boosted hex, or multiple instances of a boosted hex.

[1]: https://github.com/helium/HIP/blob/main/0109-hex-boosting-by-deployment.md