### PR TITLE
Andymck/reward manifest additions

### DIFF
--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package helium;
 
-message mobile_reward_data { uint64 bones_per_coverage_point = 1; }
+message mobile_reward_data { string bones_per_coverage_point = 1; }
 
-message iot_reward_data { uint64 bones_per_share = 1; }
+message iot_reward_data { string bones_per_share = 1; }
 
 message reward_manifest {
   repeated string written_files = 1;

--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -2,11 +2,15 @@ syntax = "proto3";
 
 package helium;
 
-message mobile_reward_data { double poc_bones_per_coverage_point = 1; }
+message mobile_reward_data {
+  double poc_bones_per_coverage_point = 1;
+  double dc_bones_per_share = 2;
+}
 
 message iot_reward_data {
   double poc_bones_per_beacon_reward_share = 1;
   double poc_bones_per_witness_reward_share = 2;
+  double dc_bones_per_share = 3;
 }
 
 message reward_manifest {

--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -2,10 +2,18 @@ syntax = "proto3";
 
 package helium;
 
+message mobile_reward_data { uint64 bones_per_coverage_point = 1; }
+
+message iot_reward_data { uint64 bones_per_share = 1; }
+
 message reward_manifest {
   repeated string written_files = 1;
   // Unix timestamp in seconds of the start of the inventory period
   uint64 start_timestamp = 2;
   // Unix timestamp in seconds of the end of the inventory period
   uint64 end_timestamp = 3;
+  oneof reward_data {
+    mobile_reward_data mobile_reward_data = 4;
+    iot_reward_data iot_reward_data = 5;
+  }
 }

--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -3,14 +3,14 @@ syntax = "proto3";
 package helium;
 
 message mobile_reward_data {
-  double poc_bones_per_coverage_point = 1;
-  double dc_bones_per_share = 2;
+  string poc_bones_per_coverage_point = 1;
+  string dc_bones_per_share = 2;
 }
 
 message iot_reward_data {
-  double poc_bones_per_beacon_reward_share = 1;
-  double poc_bones_per_witness_reward_share = 2;
-  double dc_bones_per_share = 3;
+  string poc_bones_per_beacon_reward_share = 1;
+  string poc_bones_per_witness_reward_share = 2;
+  string dc_bones_per_share = 3;
 }
 
 message reward_manifest {

--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -2,9 +2,12 @@ syntax = "proto3";
 
 package helium;
 
-message mobile_reward_data { string bones_per_coverage_point = 1; }
+message mobile_reward_data { double poc_bones_per_coverage_point = 1; }
 
-message iot_reward_data { string bones_per_share = 1; }
+message iot_reward_data {
+  double poc_bones_per_beacon_reward_share = 1;
+  double poc_bones_per_witness_reward_share = 2;
+}
 
 message reward_manifest {
   repeated string written_files = 1;


### PR DESCRIPTION
This is an attempt to include the rewards per share in the rewards manifests.  

The fields are represented as string types in this draft in an attempt to include the same precision in the protos as that used in the internal rewarder calculations.   In the rewarder these values are represented as Decimal types.  

On the IOT side the rewards per share values are rounded to a precision of 15.  On the mobile side no rounding takes place and we end up with decimal value such as

dec!(1713882.1655472017013743978648)

If the corresponding proto field is represented as a float or double this corresponds to a f64 in rust and as such when going from the rewarder's internal decimal value to an f64 we will loose precision on the mobile rewards side.  Any consumers of those protos will not be able to arrive at the same final reward values as the mobile rewarder generated.

Alternative options to consider:

1.  Represent the proto fields as floats, ignore any loss on the mobile values when going from decimal to float
2. Refactor mobile rewarder to use a default precision same as IOT ( 15 ), represent the proto types as floats.  This results in no loss of precision between internal rewarder values and external proto values
3. Other?


