### PR TITLE
add settlement status to data transfer session

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -711,8 +711,8 @@ message pending_data_transfer_session_v1 {
   uint64 rewardable_bytes = 5;
 
   // Timestamp in milliseconds since the epoch
-  // From the DataTransferEvent
-  // NOTE: Be sure to convert `data_transfer_event.timestamp` from seconds -> milliseconds
+  // From the DataTransferEvent, be sure to convert
+  // `data_transfer_event.timestamp` from seconds -> milliseconds
   uint64 event_timestamp = 6;
   // Timestamp in milliseconds since the epoch
   // From the file the transfer session was processed

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -710,8 +710,9 @@ message pending_data_transfer_session_v1 {
   uint64 download_bytes = 4;
   uint64 rewardable_bytes = 5;
 
-  // Timestamp in seconds since the epoch
+  // Timestamp in milliseconds since the epoch
   // From the DataTransferEvent
+  // NOTE: Be sure to convert `data_transfer_event.timestamp` from seconds -> milliseconds
   uint64 event_timestamp = 6;
   // Timestamp in milliseconds since the epoch
   // From the file the transfer session was processed

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -631,6 +631,13 @@ enum cell_type {
   nova_generic_wifi_outdoor = 7;
 }
 
+enum data_transfer_session_settlement_status {
+  // The Session is able to be burned immediately
+  settled = 0;
+  // The Session is pending settlement, do not burn
+  pending = 1;
+}
+
 message data_transfer_session_req_v1 {
   /// data_transfer_event represents traffic usage happening on a hotspot
   /// it is traffic quota or timer based
@@ -643,6 +650,7 @@ message data_transfer_session_req_v1 {
   bytes pub_key = 3;
   bytes signature = 4;
   uint64 rewardable_bytes = 5;
+  data_transfer_session_settlement_status status = 6;
 }
 
 message data_transfer_event {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -700,6 +700,24 @@ message invalid_data_transfer_ingest_report_v1 {
   uint64 timestamp = 3;
 }
 
+message pending_data_transfer_session_v1 {
+  // Public Key of the Hotspot
+  bytes pub_key = 1;
+  // Public Key of the Payer
+  bytes payer = 2;
+
+  uint64 upload_bytes = 3;
+  uint64 download_bytes = 4;
+  uint64 rewardable_bytes = 5;
+
+  // Timestamp in seconds since the epoch
+  // From the DataTransferEvent
+  uint64 event_timestamp = 6;
+  // Timestamp in milliseconds since the epoch
+  // From the file the transfer session was processed
+  uint64 received_timestamp = 7;
+}
+
 message oracle_boosting_report_v1 {
   // UUID of the coverage object for the given hex
   bytes coverage_object = 1;


### PR DESCRIPTION
Oracles: https://github.com/helium/oracles/pull/857

- Added `data_transfer_session_req_v1.status` of enum `data_transfer_session_settlement_status`
  - indicates whether a session can have it's DC burned immediately, or needs manual intervention
- Added `pending_data_transfer_session_v1` for publicly auditable pending sessions