### PR TITLE
Add Data Only device type

### DIFF
--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -137,6 +137,7 @@ enum device_type {
   cbrs = 0;
   wifi_indoor = 1;
   wifi_outdoor = 2;
+  wifi_data_only = 3;
 }
 
 message authorization_verify_req_v1 {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -34,6 +34,7 @@ message speedtest_ingest_report_v1 {
 enum speedtest_verification_result {
   speedtest_valid = 0;
   speedtest_gateway_not_found = 1;
+  speedtest_data_only = 2;
 }
 
 message verified_speedtest {
@@ -411,6 +412,8 @@ enum heartbeat_validity {
   heartbeat_validity_gateway_not_asserted = 10;
   // heartbeat location is outside supported locations
   heartbeat_validity_unsupported_location = 11;
+  //
+  heartbeat_validity_data_only = 12;
 }
 
 message seniority_update {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -34,7 +34,8 @@ message speedtest_ingest_report_v1 {
 enum speedtest_verification_result {
   speedtest_valid = 0;
   speedtest_gateway_not_found = 1;
-  speedtest_data_only = 2;
+  // Device Type not expected to submit speedtests
+  speedtest_invalid_device_type = 2;
 }
 
 message verified_speedtest {
@@ -412,8 +413,8 @@ enum heartbeat_validity {
   heartbeat_validity_gateway_not_asserted = 10;
   // heartbeat location is outside supported locations
   heartbeat_validity_unsupported_location = 11;
-  //
-  heartbeat_validity_data_only = 12;
+  // Device Type not expected to submit heartbeats
+  heartbeat_validity_invalid_device_type = 12;
 }
 
 message seniority_update {


### PR DESCRIPTION
Add `DeviceType.wifi_data_only`.
Add invalid reasons for speedtests and heartbeats. Data Only hotspots are not expected submit speedtests or heartbeats.