### PR TITLE
add verified data transfer ingest report

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -755,6 +755,22 @@ message invalid_data_transfer_ingest_report_v1 {
   uint64 timestamp = 3;
 }
 
+message verified_data_transfer_ingest_report_v1 {
+  enum report_status {
+    valid = 0;
+    invalid_gateway_key = 1;
+    invalid_routing_key = 2;
+    duplicate = 3;
+  }
+  // the invalid ingest report
+  data_transfer_session_ingest_report_v1 report = 1;
+  // the invalid reason as determined by the verifications
+  report_status status = 2;
+  // Timestamp at which verification was determined, in milliseconds since unix
+  // epoch
+  uint64 timestamp = 3;
+}
+
 message oracle_boosting_report_v1 {
   // UUID of the coverage object for the given hex
   bytes coverage_object = 1;


### PR DESCRIPTION
The difference between valid and invalid up to this point.
- Valid :: dc has been burned for the transfer event.
- Invalid :: We don't know one of the entities involced.

The invalid report will no longer be written. It is being replaced by Verified. All data transfer events that pass muster, we know the entities, it's not a duplicated, etc,. are written as Verified. Valid still means dc was burned.