### PR TITLE
Soft revert of service provider allocations

### DIFF
--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -8,7 +8,7 @@ import "service_provider.proto";
 message mobile_reward_data {
   Decimal poc_bones_per_reward_share = 1;
   Decimal boosted_poc_bones_per_reward_share = 2;
-  repeated service_provider_allocation sp_allocations = 3;
+  // repeated service_provider_allocation sp_allocations = 3;
 }
 
 message service_provider_allocation {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -666,7 +666,7 @@ message mobile_reward_share {
     service_provider_reward service_provider_reward = 6;
     unallocated_reward unallocated_reward = 7;
     radio_reward_v2 radio_reward_v2 = 8;
-    promotion_reward promotion_reward = 9;
+    // promotion_reward promotion_reward = 9;
   }
 }
 


### PR DESCRIPTION
- do not write them to rewards manifest or mobile rewards until flow is finalized