### PR TITLE
Add gateway_info_v2, gateway_info_stream_req_v2, gateway_metadata_v2

### DIFF
--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -158,6 +158,16 @@ message gateway_info_stream_res_v1 {
   bytes signature = 4;
 }
 
+message gateway_info_stream_res_v2 {
+  // a list of gateway info numbering up to the request batch size
+  repeated gateway_info_v2 gateways = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  bytes signature = 4;
+}
+
 message entity_verify_req_v1 {
   // binary identifier of the entity
   bytes entity_id = 1;

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -43,6 +43,7 @@ message cbrs_radio_deployment_info {
 }
 
 message gateway_metadata {
+  option deprecated = true;
   // The res12 h3 index asserted address of the gateway as a string
   // where an unasserted gateway returns an empty string
   string location = 2;
@@ -59,6 +60,7 @@ message gateway_metadata_v2 {
 }
 
 message gateway_info {
+  option deprecated = true;
   // The public key binary address and on-chain identity of the gateway
   bytes address = 1;
   // The gateway metadata as recorded on the blockchain
@@ -110,6 +112,7 @@ message gateway_info_res_v1 {
 }
 
 message gateway_info_stream_req_v1 {
+  option deprecated = true;
   // max number of gateway info records in each message of the response stream
   uint32 batch_size = 1;
   // pubkey binary of the signing keypair

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -111,6 +111,15 @@ message gateway_info_res_v1 {
   bytes signature = 4;
 }
 
+message gateway_info_res_v2 {
+  gateway_info_v2 info = 1;
+  // unix epoch timestamp in seconds
+  uint64 timestamp = 2;
+  // pubkey binary of the signing keypair
+  bytes signer = 3;
+  bytes signature = 4;
+}
+
 message gateway_info_stream_req_v1 {
   option deprecated = true;
   // max number of gateway info records in each message of the response stream
@@ -340,6 +349,9 @@ service gateway {
   // Get a stream of gateway info
   rpc info_stream(gateway_info_stream_req_v1)
       returns (stream gateway_info_stream_res_v1);
+  // Get a stream of gateway info (V2)
+  rpc info_stream_v2(gateway_info_stream_req_v2)
+      returns (stream gateway_info_stream_res_v2);
 }
 
 service entity {

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -46,6 +46,12 @@ message gateway_metadata {
   // The res12 h3 index asserted address of the gateway as a string
   // where an unasserted gateway returns an empty string
   string location = 2;
+}
+
+message gateway_metadata_v2 {
+  // The res12 h3 index asserted address of the gateway as a string
+  // where an unasserted gateway returns an empty string
+  string location = 2;
   oneof deployment_info {
     wifi_deployment_info wifi_deployment_info = 3;
     cbrs_deployment_info cbrs_deployment_info = 4;
@@ -57,6 +63,15 @@ message gateway_info {
   bytes address = 1;
   // The gateway metadata as recorded on the blockchain
   gateway_metadata metadata = 2;
+  // the asserted device type of the gateway
+  device_type device_type = 3;
+}
+
+message gateway_info_v2 {
+  // The public key binary address and on-chain identity of the gateway
+  bytes address = 1;
+  // The gateway metadata as recorded on the blockchain
+  gateway_metadata_v2 metadata = 2;
   // the asserted device type of the gateway
   device_type device_type = 3;
   // The unix epoch timestamp (in seconds)
@@ -95,6 +110,17 @@ message gateway_info_res_v1 {
 }
 
 message gateway_info_stream_req_v1 {
+  // max number of gateway info records in each message of the response stream
+  uint32 batch_size = 1;
+  // pubkey binary of the signing keypair
+  bytes signer = 2;
+  bytes signature = 3;
+  // Device types that will be returned in the response
+  // Returns all devices if empty
+  repeated device_type device_types = 4;
+}
+
+message gateway_info_stream_req_v2 {
   // max number of gateway info records in each message of the response stream
   uint32 batch_size = 1;
   // pubkey binary of the signing keypair

--- a/src/service/mobile_config.proto
+++ b/src/service/mobile_config.proto
@@ -348,7 +348,9 @@ service gateway {
       returns (stream gateway_info_stream_res_v1);
   // Get a stream of gateway info
   rpc info_stream(gateway_info_stream_req_v1)
-      returns (stream gateway_info_stream_res_v1);
+      returns (stream gateway_info_stream_res_v1) {
+    option deprecated = true;
+  }
   // Get a stream of gateway info (V2)
   rpc info_stream_v2(gateway_info_stream_req_v2)
       returns (stream gateway_info_stream_res_v2);


### PR DESCRIPTION
Since changes in gateway info response (#429, #430) breaks backward compatibility (due to signing message from server side and verifying on client):
- revert (v1) changes
- make v2 version
- make v1 version deprecated