### PR TITLE
Add rewarded token type enum to {subdao}_reward_data in reward manifest

### DIFF
--- a/src/reward_manifest.proto
+++ b/src/reward_manifest.proto
@@ -5,10 +5,17 @@ package helium;
 import "decimal.proto";
 import "service_provider.proto";
 
+enum mobile_reward_token {
+  mobile_reward_token_mobile = 0;
+  mobile_reward_token_hnt = 1;
+}
+
 message mobile_reward_data {
   Decimal poc_bones_per_reward_share = 1;
   Decimal boosted_poc_bones_per_reward_share = 2;
   repeated service_provider_promotions service_provider_promotions = 3;
+  // HIP-138: Reward output was changed from Subdao Tokens to HNT
+  mobile_reward_token token = 4;
 }
 
 message service_provider_promotions {
@@ -30,10 +37,17 @@ message service_provider_promotions {
   repeated promotion promotions = 3;
 }
 
+enum iot_reward_token {
+  iot_reward_token_iot = 0;
+  iot_reward_token_hnt = 1;
+}
+
 message iot_reward_data {
   Decimal poc_bones_per_beacon_reward_share = 1;
   Decimal poc_bones_per_witness_reward_share = 2;
   Decimal dc_bones_per_share = 3;
+  // HIP-138: Reward output was changed from Subdao Tokens to HNT
+  iot_reward_token token = 4;
 }
 
 message reward_manifest {


### PR DESCRIPTION
Two enum are needed so the default value for each reward_data type can be the corresponding subdao token for historical files that do not have these fields.

Ref: HIP-138 https://github.com/helium/HIP/blob/main/0138-return-to-hnt.md

Rewards will no longer be output in subdao tokens, only HNT.

These fields are in the reward_manifest because they are part of the metadata of the rewards.