### PR TITLE
Mj/update tonic prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ path = "src/lib.rs"
 members = ["beacon"]
 
 [workspace.dependencies]
-# Pin to 0.10 to avoid issues with tls and solana dalek deps
-tonic = { version = "0.10" }
 bytes = "1"
-prost = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tonic-build = { version = "0.10" }
-prost-build = "0.12"
+tonic = { version = "0.13" }
+tonic-build = { version = "0.13" }
+prost = "0.13"
+prost-build = "0.13"
 
 [features]
 default= []

--- a/beacon/src/region.rs
+++ b/beacon/src/region.rs
@@ -1,7 +1,7 @@
 use super::{Error, Result};
 use helium_proto::{
-    services::iot_config::GatewayRegionParamsResV1, BlockchainRegionParamV1,
-    BlockchainRegionParamsV1, DataRate, Message, Region as ProtoRegion, RegionSpreading,
+    prost::Message, services::iot_config::GatewayRegionParamsResV1, BlockchainRegionParamV1,
+    BlockchainRegionParamsV1, DataRate, Region as ProtoRegion, RegionSpreading,
 };
 use rust_decimal::prelude::{Decimal, ToPrimitive};
 use serde::{de, Deserialize, Deserializer};

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
     config!(tonic_build::configure())
         .build_server(true)
         .build_client(true)
-        .compile(
+        .compile_protos(
             &MESSAGES
                 .iter()
                 .chain(SERVICES)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 include!(concat!(env!("OUT_DIR"), "/helium.rs"));
 
 pub use blockchain_txn::Txn;
-pub use prost::{DecodeError, EncodeError, Message};
 pub use strum::IntoEnumIterator;
+
+pub use prost;
+pub use tonic;
 
 #[cfg(feature = "services")]
 pub mod services {
@@ -105,7 +107,6 @@ pub mod services {
         pub use transaction_client::TransactionClient as Client;
         pub use transaction_server::TransactionServer as Server;
     }
-    pub use tonic::transport::*;
 }
 
 impl std::str::FromStr for ServiceProvider {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,12 @@ pub use blockchain_txn::Txn;
 pub use strum::IntoEnumIterator;
 
 pub use prost;
+#[cfg(feature = "services")]
 pub use tonic;
 
 #[cfg(feature = "services")]
 pub mod services {
+
     use crate::{
         BlockchainRegionParamsV1, BlockchainTokenTypeV1, BlockchainTxn, BoostedHexInfoV1, DataRate,
         Decimal, EntropyReportV1, GatewayStakingMode, MapperAttach, Region, RoutingAddress,


### PR DESCRIPTION
[Re-export tonic and prost as top level exports](https://github.com/helium/proto/commit/a6378d78bd3492407c64a72ad0b24ee9d8742d7d) 

This ensures downstream has access to all the types from the expected versions of tonic and prost. And clarifies where things like `DecodeError` come from in their imports.