### PR TITLE
Introduce carrier_id_v2 enum

### DIFF
--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -64,17 +64,17 @@ enum carrier_id {
 // V2 is introduced to satisfy backward compatibility.
 // We have to set the 0 value as unspecified
 enum carrier_id_v2 {
-  unspecified = 0;
-  carrier0 = 1;
-  carrier1 = 2;
-  carrier2 = 3;
-  carrier3 = 4;
-  carrier4 = 5;
-  carrier5 = 6;
-  carrier6 = 7;
-  carrier7 = 8;
-  carrier8 = 9;
-  carrier9 = 10;
+  carrier_id_v2_unspecified = 0;
+  carrier_id_v2_carrier0 = 1;
+  carrier_id_v2_carrier1 = 2;
+  carrier_id_v2_carrier2 = 3;
+  carrier_id_v2_carrier3 = 4;
+  carrier_id_v2_carrier4 = 5;
+  carrier_id_v2_carrier5 = 6;
+  carrier_id_v2_carrier6 = 7;
+  carrier_id_v2_carrier7 = 8;
+  carrier_id_v2_carrier8 = 9;
+  carrier_id_v2_carrier9 = 10;
 }
 
 message radio_usage_carrier_transfer_info {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -65,16 +65,16 @@ enum carrier_id {
 // We have to set the 0 value as unspecified
 enum carrier_id_v2 {
   carrier_id_v2_unspecified = 0;
-  carrier_id_v2_carrier0 = 1;
-  carrier_id_v2_carrier1 = 2;
-  carrier_id_v2_carrier2 = 3;
-  carrier_id_v2_carrier3 = 4;
-  carrier_id_v2_carrier4 = 5;
-  carrier_id_v2_carrier5 = 6;
-  carrier_id_v2_carrier6 = 7;
-  carrier_id_v2_carrier7 = 8;
-  carrier_id_v2_carrier8 = 9;
-  carrier_id_v2_carrier9 = 10;
+  carrier_id_v2_carrier_0 = 1;
+  carrier_id_v2_carrier_1 = 2;
+  carrier_id_v2_carrier_2 = 3;
+  carrier_id_v2_carrier_3 = 4;
+  carrier_id_v2_carrier_4 = 5;
+  carrier_id_v2_carrier_5 = 6;
+  carrier_id_v2_carrier_6 = 7;
+  carrier_id_v2_carrier_7 = 8;
+  carrier_id_v2_carrier_8 = 9;
+  carrier_id_v2_carrier_9 = 10;
 }
 
 message radio_usage_carrier_transfer_info {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -919,8 +919,7 @@ message data_transfer_session_req_v1 {
   bytes pub_key = 3;
   bytes signature = 4;
   uint64 rewardable_bytes = 5;
-  carrier_id carrier_id = 6 [ deprecated = true ];
-  carrier_id_v2 carrier_id_v2 = 7;
+  carrier_id_v2 carrier_id_v2 = 6;
 }
 
 message data_transfer_event {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -78,7 +78,7 @@ enum carrier_id_v2 {
 }
 
 message radio_usage_carrier_transfer_info {
-  carrier_id carrier_id = 1;
+  carrier_id carrier_id = 1 [ deprecated = true ];
   uint64 transfer_bytes = 2;
   uint64 user_count = 3;
   carrier_id_v2 carrier_id_v2 = 4;
@@ -919,7 +919,7 @@ message data_transfer_session_req_v1 {
   bytes pub_key = 3;
   bytes signature = 4;
   uint64 rewardable_bytes = 5;
-  carrier_id carrier_id = 6;
+  carrier_id carrier_id = 6 [ deprecated = true ];
   carrier_id_v2 carrier_id_v2 = 7;
 }
 

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -48,16 +48,17 @@ message hex_usage_stats_ingest_report_v1 {
 }
 
 enum carrier_id {
-  carrier_0 = 0;
-  carrier_1 = 1;
-  carrier_2 = 2;
-  carrier_3 = 3;
-  carrier_4 = 4;
-  carrier_5 = 5;
-  carrier_6 = 6;
-  carrier_7 = 7;
-  carrier_8 = 8;
-  carrier_9 = 9;
+  unspecified = 0;
+  carrier_0 = 1;
+  carrier_1 = 2;
+  carrier_2 = 3;
+  carrier_3 = 4;
+  carrier_4 = 5;
+  carrier_5 = 6;
+  carrier_6 = 7;
+  carrier_7 = 8;
+  carrier_8 = 9;
+  carrier_9 = 10;
 }
 
 message radio_usage_carrier_transfer_info {

--- a/src/service/poc_mobile.proto
+++ b/src/service/poc_mobile.proto
@@ -48,6 +48,7 @@ message hex_usage_stats_ingest_report_v1 {
 }
 
 enum carrier_id {
+  option deprecated = true;
   carrier_0 = 0;
   carrier_1 = 1;
   carrier_2 = 2;
@@ -60,24 +61,27 @@ enum carrier_id {
   carrier_9 = 9;
 }
 
+// V2 is introduced to satisfy backward compatibility.
+// We have to set the 0 value as unspecified
 enum carrier_id_v2 {
   unspecified = 0;
-  carrier_0 = 1;
-  carrier_1 = 2;
-  carrier_2 = 3;
-  carrier_3 = 4;
-  carrier_4 = 5;
-  carrier_5 = 6;
-  carrier_6 = 7;
-  carrier_7 = 8;
-  carrier_8 = 9;
-  carrier_9 = 10;
+  carrier0 = 1;
+  carrier1 = 2;
+  carrier2 = 3;
+  carrier3 = 4;
+  carrier4 = 5;
+  carrier5 = 6;
+  carrier6 = 7;
+  carrier7 = 8;
+  carrier8 = 9;
+  carrier9 = 10;
 }
 
 message radio_usage_carrier_transfer_info {
   carrier_id carrier_id = 1;
   uint64 transfer_bytes = 2;
   uint64 user_count = 3;
+  carrier_id_v2 carrier_id_v2 = 4;
 }
 
 message radio_usage_stats_req_v1 {
@@ -916,6 +920,7 @@ message data_transfer_session_req_v1 {
   bytes signature = 4;
   uint64 rewardable_bytes = 5;
   carrier_id carrier_id = 6;
+  carrier_id_v2 carrier_id_v2 = 7;
 }
 
 message data_transfer_event {


### PR DESCRIPTION
V2 is introduced to satisfy backward compatibility.
We have to set the 0 value as unspecified